### PR TITLE
Update to C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 # Set the relevant generic compiler flags (optimisation + warnings)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -Wextra -Wmissing-declarations -Wpointer-arith -Wshadow -Wuninitialized -Winit-self -Wundef -Wcast-align -Wformat=2 -Wold-style-cast -Werror=switch -std=c++11 -mfpmath=sse")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W -Wall -Wextra -Wmissing-declarations -Wpointer-arith -Wshadow -Wuninitialized -Winit-self -Wundef -Wcast-align -Wformat=2 -Wold-style-cast -Werror=switch -std=c++17 -mfpmath=sse")
 message(STATUS "CXX_FLAGS = " ${CMAKE_CXX_FLAGS})
 
 # Collect all the cpp files

--- a/src/include/oscaroutput.h
+++ b/src/include/oscaroutput.h
@@ -11,14 +11,14 @@
 
 void write_oscar_output() {
   // initialize Oscar output
-  const smash::bf::path OutputPath = params::sSpectraDir;
+  const std::filesystem::path OutputPath = params::sSpectraDir;
   std::unique_ptr<smash::OutputInterface> OscarOutput =
        create_oscar_output("Oscar2013", "Particles", OutputPath,
                            smash::OutputParameters());
 
   for(int iev=0; iev<params::NEVENTS; iev++){
     // Create Particles oject which contains the full particle list of each event
-    std::unique_ptr<smash::Particles> particles = smash::make_unique<smash::Particles>();
+    std::unique_ptr<smash::Particles> particles = std::make_unique<smash::Particles>();
 
     for(int inpart=0; inpart<gen::npart[iev]; inpart++) {
       smash::ParticleData* data = gen::pList[iev][inpart];


### PR DESCRIPTION
Replacing boost dependence and updating to C++17 in the current development branch will also require changes in the hadron sampler. These changes will break backwards compatibility.