### PR TITLE
Sass/spin sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :heavy_plus_sign: A testing framework was added
+* :heavy_plus_sign: The (boolean) key "sample_spin" was added
+* :heavy_plus_sign: The (double) key "polarization" was added
+* :heavy_plus_sign: A spin sampling procedure was added in order to set spin states at freezeout when "sample_spin" is set to true, given a polarization controlled by the key "polarization"
+
 ## SMASH-hadron-sampler-3.0
 Date: 2023-04-28
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,10 @@ if(${SMASH_FOUND})
   else()
     message(FATAL_ERROR "Environment variable SMASH_DIR unset. Unable to include virtest.")
   endif()
-endif(${SMASH_FOUND})
+else()
+  message(FATAL_ERROR "SMASH could not be found.")
+endif()
+
 
 find_package(ROOT 5.34)
 if(ROOT_FOUND)

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -50,10 +50,17 @@ void fillBoostMatrix(double vx, double vy, double vz, double boostMatrix [4][4])
 
 
 // index44: returns an index of pi^{mu nu} mu,nu component in a plain 1D array
-int index44(const int &i, const int &j){
-  if(i>3 || j>3 || i<0 || j<0) {std::cout<<"index44: i j " <<i<<" "<<j<<endl ; exit(1) ; }
-  if(j<i) return (i*(i+1))/2 + j ;
-  else return (j*(j+1))/2 + i ;
+int index44(const int &i, const int &j) {
+  // Index out of range
+  if (i > 3 || j > 3 || i < 0 || j < 0) {
+    throw std::out_of_range("Index out of range [0, 3]. Indices passed are (" +
+                            std::to_string(i) + ", " + std::to_string(j) + ")");
+  }
+  if (j < i) {
+    return (i * (i + 1)) / 2 + j;
+  } else {
+    return (j * (j + 1)) / 2 + i;
+  }
 }
 
 

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -386,7 +386,7 @@ void acceptParticle(int ievent, const smash::ParticleTypePtr &ldef,
  new_particle->set_4position(position);
 
  if (params::is_spin_sampling_on && !(std::isnan(vorticity_cell))) {
-    const double polarization_percentage = 0.05;
+    const double polarization_percentage = params::global_polarization ;
     const int favored_spin = get_favored_spin_projection_in_cell(
         vorticity_cell, min_max_vorticity, new_particle->spin());
     const int sampled_spin_projection =

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -56,6 +56,9 @@ int index44(const int &i, const int &j){
 
 namespace gen{
 
+int test(const double h) {
+  return static_cast<int>(h);
+}
 
 int Nelem ;
 double *ntherm, dvMax, dsigmaMax ;

--- a/src/include/gen.h
+++ b/src/include/gen.h
@@ -4,9 +4,9 @@
 #include "smash/particles.h"
 #include "smash/setup_particles_decaymodes.h"
 
-class TRandom3 ;
+class TRandom3;
 class DatabasePDG2;
-class Particle ;
+class Particle;
 
 int index44(const int &i, const int &j);
 
@@ -18,9 +18,48 @@ extern smash::ParticleData ***pList ; // particle arrays
 extern int *npart ;
 const int NPartBuf = 30000; // dimension of particle buffer for each event
 
-// functions
-void load(char *filename, int N) ;
-int generate() ;
-}
+struct MinMax {
+  double minimum;
+  double maximum;
+};
 
-#endif // INCLUDE_GEN_H_
+
+// functions
+void load(char *filename, int N, MinMax &min_max_vorticity);
+int generate();
+void acceptParticle(int event, const smash::ParticleTypePtr &ldef,
+                    smash::FourVector position, smash::FourVector momentum);
+
+/*
+ * Get the most likely spin projection in one cell in multiples of 1/2, based on
+ * it's vorticity
+ * \return Favored spin projection in multiples of 1/2
+ */
+int get_favored_spin_projection_in_cell(double vorticity_cell,
+                                        MinMax &min_max_vorticity);
+
+/*
+ * Calculate the z projection of the vorticity in the given cell.
+ * This is used to sample spin projections of particles.
+ */
+double get_vorticity_z_projection_in_cell(double (&u)[4],
+                                          double (&u_derivatives)[16]);
+/*
+ * Updates the min and max values in min_max_vorticity with every loop over each
+ * element, such that min_max_vorticity stores the absolute minimum and maximum
+ * of the z projection of the vorticity over the whole surface in the end
+ */
+void update_min_max_vorticity_values(int iterator, double vorticity_cell,
+                                     MinMax &min_max_vorticity);
+
+/*
+ * Sample the spin projection of a particle based on the vorticity (z
+ * projection) of the corresponding cell. First the most likely spin state
+ * is determined, afterwards the actual spin state is sampled with a
+ * Monte-Carlo sampling, with the acceptance range adjusted according to the
+ * most likely spin projection determined before.
+ */
+int get_sampled_spin_projection();
+}  // namespace gen
+
+#endif  // INCLUDE_GEN_H_

--- a/src/include/gen.h
+++ b/src/include/gen.h
@@ -35,8 +35,9 @@ void acceptParticle(int event, const smash::ParticleTypePtr &ldef,
  * it's vorticity
  * \return Favored spin projection in multiples of 1/2
  */
-int get_favored_spin_projection_in_cell(double vorticity_cell,
-                                        MinMax &min_max_vorticity);
+int get_favored_spin_projection_in_cell(const double vorticity_cell,
+                                        const MinMax &min_max_vorticity,
+                                        const int spin);
 
 /*
  * Calculate the z projection of the vorticity in the given cell.

--- a/src/include/gen.h
+++ b/src/include/gen.h
@@ -23,12 +23,12 @@ struct MinMax {
   double maximum;
 };
 
-
 // functions
-void load(char *filename, int N, MinMax &min_max_vorticity);
+void load(char *filename, int N);
 int generate();
 void acceptParticle(int event, const smash::ParticleTypePtr &ldef,
-                    smash::FourVector position, smash::FourVector momentum);
+                    smash::FourVector position, smash::FourVector momentum,
+                    double vorticity_cell);
 
 /*
  * Get the most likely spin projection in one cell in multiples of 1/2, based on
@@ -36,7 +36,7 @@ void acceptParticle(int event, const smash::ParticleTypePtr &ldef,
  * \return Favored spin projection in multiples of 1/2
  */
 int get_favored_spin_projection_in_cell(const double vorticity_cell,
-                                        const MinMax &min_max_vorticity,
+                                        const MinMax &vorticity_extrema,
                                         const int spin);
 
 /*
@@ -50,8 +50,8 @@ double get_vorticity_z_projection_in_cell(double (&u)[4],
  * element, such that min_max_vorticity stores the absolute minimum and maximum
  * of the z projection of the vorticity over the whole surface in the end
  */
-void update_min_max_vorticity_values(int iterator, double vorticity_cell,
-                                     MinMax &min_max_vorticity);
+void update_vorticity_extrema(int iterator, double vorticity_cell,
+                                     MinMax &vorticity_extrema);
 
 /*
  * Sample the spin projection of a particle based on the vorticity (z
@@ -60,7 +60,8 @@ void update_min_max_vorticity_values(int iterator, double vorticity_cell,
  * Monte-Carlo sampling, with the acceptance range adjusted according to the
  * most likely spin projection determined before.
  */
-int get_sampled_spin_projection();
+int sample_spin_projection(const int spin, const int favored_spin_projection,
+                           const double polarization_percentage);
 }  // namespace gen
 
 #endif  // INCLUDE_GEN_H_

--- a/src/include/gen.h
+++ b/src/include/gen.h
@@ -29,7 +29,12 @@ int generate();
 void acceptParticle(int event, const smash::ParticleTypePtr &ldef,
                     smash::FourVector position, smash::FourVector momentum,
                     double vorticity_cell);
-
+/*
+* Check that the vorticity extrema have been set and that the vorticity
+* in the cell does not exceed those extrema. Throw exception otherwise.
+*/
+void check_if_vorticity_values_are_valid(const double vorticity_cell,
+                                         const MinMax &vorticity_extrema);
 /*
  * Get the most likely spin projection in one cell in multiples of 1/2, based on
  * it's vorticity

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -1,18 +1,35 @@
 #ifndef INCLUDE_PARAMS_H_
 #define INCLUDE_PARAMS_H_
 
-namespace params{
-extern char sSurface [255], sSpectraDir [255];
-extern bool weakContribution ;
-extern bool rescatter ;
-extern bool shear ;
-extern bool bulk ;
-//extern double Temp, mu_b, mu_q, mu_s ;
-extern int NEVENTS ;
-extern double NBINS, QMAX ;
-extern double dx, dy, deta ;
-extern double ecrit, cs2, ratio_pressure_energydensity ;
+namespace params {
+extern char sSurface[255], sSpectraDir[255];
+extern bool weakContribution;
+extern bool rescatter;
+extern bool shear;
+extern bool bulk;
+// extern double Temp, mu_b, mu_q, mu_s ;
+extern int NEVENTS;
+extern double NBINS, QMAX;
+extern double dx, dy, deta;
+extern double ecrit, cs2, ratio_pressure_energydensity;
+/**
+ * Controls whether spin sampling is used during simulations, in order to set
+ * the projections of spin degrees of freedom at freezeout.
+ *
+ * **Default Value:** False
+ */
 extern bool is_spin_sampling_on;
+/**
+ * This parameter influences the probability of sampling a spin projection that
+ * aligns with the vorticity by more than 50%.
+ *
+ * A value of 0.0 indicates no preference (equal probability for any spin
+ * projection), while larger values favor spins aligned with the (local)
+ * vorticity and negative values anti-alignment.
+ * 
+ * **Default Value:** False
+ */
+extern double global_polarization;
 
 // ---- rooutines ----
 void readParams(char* filename);

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -12,10 +12,11 @@ extern int NEVENTS ;
 extern double NBINS, QMAX ;
 extern double dx, dy, deta ;
 extern double ecrit, cs2, ratio_pressure_energydensity ;
+extern bool is_spin_sampling_on;
 
 // ---- rooutines ----
-void readParams(char* filename) ;
-void printParameters() ;
-}
+void readParams(char* filename);
+void printParameters();
+}  // namespace params
 
-#endif // INCLUDE_PARAMS_H_
+#endif  // INCLUDE_PARAMS_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,12 +42,7 @@ int main(int argc, char **argv)
   gen::rnd = random3 ;
 
  // ========== generator init
- /*
- * Stores the minimum and maximum value of the z projection of 
- * the vorticity over the whole freezeout surface. 
- */
- gen::MinMax min_max_vorticity ;
- gen::load(sSurface, getNlines(sSurface), min_max_vorticity) ;
+ gen::load(sSurface, getNlines(sSurface)) ;
 
  // ========== trees & files
  time_t start, end ;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,12 @@ int main(int argc, char **argv)
   gen::rnd = random3 ;
 
  // ========== generator init
- gen::load(sSurface,getNlines(sSurface)) ;
+ /*
+ * Stores the minimum and maximum value of the z projection of 
+ * the vorticity over the whole freezeout surface. 
+ */
+ gen::MinMax min_max_vorticity ;
+ gen::load(sSurface, getNlines(sSurface), min_max_vorticity) ;
 
  // ========== trees & files
  time_t start, end ;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -23,6 +23,7 @@ double dx, dy, deta ;
 double ecrit ;
 double cs2=0.15;
 double ratio_pressure_energydensity=0.15;
+double global_polarization=0.0;
 
 // ############ reading and processing the parameters
 
@@ -49,6 +50,7 @@ void readParams(char* filename)
 		else if(strcmp(parName,"cs2")==0) cs2 = atof(parValue) ;
 		else if(strcmp(parName,"ratio_pressure_energydensity")==0) ratio_pressure_energydensity = atof(parValue) ;
 		else if(strcmp(parName, "sample_spin") == 0) is_spin_sampling_on = atoi(parValue);
+		else if(strcmp(parName, "polarization") == 0) global_polarization = atof(parValue);
 		else if(parName[0]=='!') cout << "CCC " << sline.str() << endl ;
 		else cout << "UUU " << sline.str() << endl ;
 	}
@@ -71,6 +73,7 @@ void printParameters()
   cout << "cs2 = " << cs2 << endl ;
   cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity << endl ;
   cout << "spin_sampling_on = " << is_spin_sampling_on << endl ;
+  cout << "polarization" << global_polarization << endl ;
   cout << "======= end parameters =======\n" ;
 }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -47,6 +47,7 @@ void readParams(char* filename)
 		else if(strcmp(parName,"ecrit")==0) ecrit = atof(parValue) ;
 		else if(strcmp(parName,"cs2")==0) cs2 = atof(parValue) ;
 		else if(strcmp(parName,"ratio_pressure_energydensity")==0) ratio_pressure_energydensity = atof(parValue) ;
+		else if(strcmp(parName, "sample_spin") == 0) is_spin_sampling_on = atoi(parValue);
 		else if(parName[0]=='!') cout << "CCC " << sline.str() << endl ;
 		else cout << "UUU " << sline.str() << endl ;
 	}

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -15,6 +15,7 @@ bool weakContribution ;
 bool rescatter ;
 bool shear ;
 bool bulk ;
+bool is_spin_sampling_on;
 //double Temp, mu_b, mu_q, mu_s ;
 int NEVENTS ;
 double NBINS, QMAX ;
@@ -69,6 +70,7 @@ void printParameters()
   cout << "q_max = " << QMAX << endl ;
   cout << "cs2 = " << cs2 << endl ;
   cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity << endl ;
+  cout << "spin_sampling_on = " << is_spin_sampling_on << endl ;
   cout << "======= end parameters =======\n" ;
 }
 

--- a/tests/gen.cpp
+++ b/tests/gen.cpp
@@ -12,3 +12,43 @@ TEST(index44) {
     }
   }
 }
+
+TEST(favored_spin_projection_valid) {
+  MinMax limits = {-1.0, 1.0};
+  int spin;
+
+  // Spin 1/2 -> s = 1
+  for (double vorticity = limits.minimum; vorticity <= limits.maximum;
+       vorticity += 0.01) {
+    spin = get_favored_spin_projection_in_cell(vorticity, limits, 1);
+    if (vorticity < 0.0) {
+      VERIFY(spin == -1);
+    } else {
+      VERIFY(spin == 1);
+    }
+  }
+  // Value exactly at the binning edges
+  spin = get_favored_spin_projection_in_cell(-1.0, limits, 1);
+  VERIFY(spin == -1);
+  spin = get_favored_spin_projection_in_cell(0.0, limits, 1);
+  VERIFY(spin == 1);
+  spin = get_favored_spin_projection_in_cell(1.0, limits, 1);
+  VERIFY(spin == 1);
+
+  // Spin 1 -> s = 2
+  const double bin_width = (limits.maximum - limits.minimum) / 3.;
+
+  for (double vorticity = limits.minimum; vorticity <= limits.maximum;
+       vorticity += 0.01) {
+    spin = get_favored_spin_projection_in_cell(vorticity, limits, 2);
+    if (vorticity < (limits.minimum + bin_width)) {
+      VERIFY(spin == -2);
+    } else if ((limits.minimum + bin_width) <= vorticity &&
+               vorticity < (limits.minimum + (2. * bin_width))) {
+      VERIFY(spin == 0);
+    } else if ((limits.minimum + (2. * bin_width)) <= vorticity &&
+               vorticity < limits.maximum) {
+      VERIFY(spin == 2);
+    }
+  }
+}

--- a/tests/gen.cpp
+++ b/tests/gen.cpp
@@ -20,6 +20,39 @@ TEST(index44) {
   }
 }
 
+TEST(index44_index_out_of_range) {
+  int valid_index[4] = {0, 1, 2, 3};
+  int invalid_index[4] = {-2, -1, 4, 5};
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      // first index out of range
+      try {
+        index44(invalid_index[i], valid_index[j]);
+        std::cout << "index44 unexpectedly passed with first argument "
+                  << "out of range" << std::endl;
+      } catch (std::out_of_range &e) {
+        // Exception was caught as expected
+      }
+      // second index out of range
+      try {
+        index44(valid_index[i], invalid_index[j]);
+        std::cout << "index44 unexpectedly passed with second argument "
+                  << "out of range" << std::endl;
+      } catch (std::out_of_range &e) {
+        // Exception was caught as expected
+      }
+      // both indices out of range
+      try {
+        index44(invalid_index[i], invalid_index[j]);
+        std::cout << "index44 unexpectedly passed with both arguments "
+                  << "out of range" << std::endl;
+      } catch (std::out_of_range &e) {
+        // Exception was caught as expected
+      }
+    }
+  }
+}
+
 TEST(vorticity_validity) {
   // Unset vorticity extrema
   MinMax limits_1 = {-5.9, std::numeric_limits<double>::quiet_NaN()};

--- a/tests/gen.cpp
+++ b/tests/gen.cpp
@@ -220,6 +220,7 @@ static bool check_other_elements_than_given_index(
 
 TEST(spin_sampling_probability) {
   const double precision = 0.01;
+  const double epsilon = 0.0001;
   const int num_samples = 600000;
   const double polarization = 0.2;
 
@@ -251,7 +252,6 @@ TEST(spin_sampling_probability) {
 
     for (int favored_spin = 0; favored_spin <= spin; favored_spin++) {
       // Loop over samples to generate statistics and fill counts
-
       for (int sample = 0; sample < num_samples; sample++) {
         int state = sample_spin_projection(spin, valid_states[favored_spin],
                                            polarization);
@@ -259,11 +259,12 @@ TEST(spin_sampling_probability) {
         int index = (state + spin) / 2;
         counts[index]++;
       }
+
       // Check that sum of all counts coincides with num_samples
       int sum_counts = std::accumulate(counts.begin(), counts.end(), 0);
       VERIFY(sum_counts == num_samples);
 
-      // Check that the favored probability is set correctly
+      // Check that the favored probability is sampled correctly
       double probability =
           static_cast<double>(counts[favored_spin]) / num_samples;
       VERIFY(std::abs(probability - favored_probability) < precision);
@@ -275,6 +276,13 @@ TEST(spin_sampling_probability) {
                                                 disfavored_probability,
                                                 num_samples, precision);
       VERIFY(are_other_probabilities_disfavored);
+
+      // Check that the sum of all probabilities is normalized to 1
+      double total_probability = 0.0;
+      for (int count : counts) {
+        total_probability += static_cast<double>(count) / num_samples;
+      }
+      VERIFY(std::abs(total_probability - 1.0) <= epsilon);
 
       // Reset counts for next favored spin index
       counts.assign(counts.size(), 0);

--- a/tests/gen.cpp
+++ b/tests/gen.cpp
@@ -1,6 +1,13 @@
 #include "gen.h"
 
+#include <ctime>
+#include <limits>
+#include <numeric>
+#include <random>
+#include <vector>
+
 #include "virtest/vir/test.h"
+
 using namespace gen;
 
 TEST(index44) {
@@ -13,7 +20,43 @@ TEST(index44) {
   }
 }
 
-TEST(favored_spin_projection_valid) {
+TEST(vorticity_validity) {
+  // Unset vorticity extrema
+  MinMax limits_1 = {-5.9, std::numeric_limits<double>::quiet_NaN()};
+  MinMax limits_2 = {std::numeric_limits<double>::quiet_NaN(), 5.9};
+  MinMax limits_3 = {std::numeric_limits<double>::quiet_NaN(),
+                     std::numeric_limits<double>::quiet_NaN()};
+  MinMax limits_array[3] = {limits_1, limits_2, limits_3};
+
+  for (MinMax limits : limits_array) {
+    try {
+      check_if_vorticity_values_are_valid(1.9, limits);
+      std::cout << "Value Error: check_if_vorticity_values_are_valid() "
+                << " unexpectedly passed with invalid vorticity extrema "
+                << std::endl;
+      FAIL();
+    } catch (std::invalid_argument &e) {
+      // Exception was caught as expected
+    }
+  }
+  // Vorticity in cell exceeds vorticity extrema
+  MinMax limits = {-1.0, 1.0};
+  double invalid_vorticity[6] = {-999.9, -2.5, -1.01, 1.01, 2.5, 999.9};
+  for (double vorticity : invalid_vorticity) {
+    try {
+      check_if_vorticity_values_are_valid(vorticity, limits);
+      std::cout
+          << "Initialization Error:  get_favored_spin_projection_in_cell() "
+          << " unexpectedly passed with invalid vorticity extrema "
+          << std::endl;
+      FAIL();
+    } catch (std::invalid_argument &e) {
+      // Exception was caught as expected
+    }
+  }
+}
+
+TEST(favored_spin_projection) {
   MinMax limits = {-1.0, 1.0};
   int spin;
 
@@ -49,6 +92,202 @@ TEST(favored_spin_projection_valid) {
     } else if ((limits.minimum + (2. * bin_width)) <= vorticity &&
                vorticity < limits.maximum) {
       VERIFY(spin == 2);
+    }
+  }
+}
+
+TEST(update_vorticity_extrema) {
+  const int num_values = 1000;
+  MinMax vorticity_extrema = {std::numeric_limits<double>::quiet_NaN(),
+                              std::numeric_limits<double>::quiet_NaN()};
+  std::vector<double> values(num_values);
+
+  // Fill the vector with random values (negative to positive)
+  std::default_random_engine generator(std::time(nullptr));
+  std::uniform_real_distribution<double> distribution(-10.0, 10.0);
+  for (int i = 0; i < num_values; ++i) {
+    values[i] = distribution(generator);
+    update_vorticity_extrema(i, values[i], vorticity_extrema);
+  }
+  // Find both minimum and maximum values of the vector
+  auto min_max_pair = std::minmax_element(values.begin(), values.end());
+  const double min_value = *min_max_pair.first;
+  const double max_value = *min_max_pair.second;
+
+  VERIFY(vorticity_extrema.minimum == min_value);
+  VERIFY(vorticity_extrema.maximum == max_value);
+}
+
+TEST(spin_sampling_return_values) {
+  const int num_samples = 50000;
+  // Spin 0
+  for (int i = 0; i < num_samples; i++) {
+    int state = sample_spin_projection(0, 0, 0.0);
+    VERIFY(state == 0);
+  }
+  // Spin 1
+  for (int i = 0; i < num_samples; i++) {
+    int state = sample_spin_projection(1, 1, 0.2);
+    VERIFY(state == -1 || state == 1);
+  }
+  // Spin 2
+  for (int i = 0; i < num_samples; i++) {
+    int state = sample_spin_projection(2, -2, 0.2);
+    VERIFY(state == -2 || state == 0 || state == 2);
+  }
+  // Spin 3
+  for (int i = 0; i < num_samples; i++) {
+    int state = sample_spin_projection(3, 3, 0.2);
+    VERIFY(state == -3 || state == -1 || state == 1 || state == 3);
+  }
+  // Spin 4
+  for (int i = 0; i < num_samples; i++) {
+    int state = sample_spin_projection(4, -4, 0.2);
+    VERIFY(state == -4 || state == -2 || state == 0 || state == 2 ||
+           state == 4);
+  }
+  // Spin 5
+  for (int i = 0; i < num_samples; i++) {
+    int state = sample_spin_projection(5, 3, 0.2);
+    VERIFY(state == -5 || state == -3 || state == -1 || state == 1 ||
+           state == 3 || state == 5);
+  }
+}
+
+// Given a vector of num_samples counts distributed among its elements, check
+// that all counts but those in the element `skip_index`coincide with
+// `probability` up to a given `precision` in percent.
+static bool check_other_elements_than_given_index(
+    const std::vector<int> &values, int skip_index, double probability,
+    int num_samples, double precision) {
+  // No other element to check
+  if (values.size() == 1) {
+    return true;
+  } else {
+    size_t index_to_skip = static_cast<size_t>(skip_index);
+
+    // Check if index_to_skip is within the bounds of the vector
+    if (index_to_skip >= values.size() || index_to_skip < 0) {
+      throw std::out_of_range("Index to skip is out of range.");
+    }
+
+    // Iterate over all elements except values[favored_spin]
+    for (size_t i = 0; i < values.size(); ++i) {
+      if (i != index_to_skip) {
+        double disfavored_probability =
+            static_cast<double>(values[i]) / num_samples;
+        if (std::abs(disfavored_probability - probability) > precision) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}
+
+TEST(spin_sampling_probability) {
+  const double precision = 0.01;
+  const int num_samples = 600000;
+  const double polarization = 0.2;
+
+  // Loop through different spin states
+  for (int spin = 0; spin < 6; spin++) {
+    double num_states = spin + 1;
+    double base_probability = 1.0 / num_states;
+
+    // Calculate the probabilities for the favored state and all others
+    double favored_probability;
+    double disfavored_probability;
+    if (spin == 0) {
+      favored_probability = 1.0;
+      disfavored_probability = 0.0;
+    } else {
+      favored_probability = (1. + polarization) * base_probability;
+      disfavored_probability = (1.0 - favored_probability) / (num_states - 1);
+    }
+
+    // Create and fill the vector with allowed states (even values from -spin to
+    // spin)
+    std::vector<int> valid_states(num_states);
+    for (int i = 0; i < num_states; ++i) {
+      valid_states[i] = -spin + 2 * i;
+    }
+
+    // Create a vector to store the counts for each allowed state
+    std::vector<int> counts(spin + 1, 0);
+
+    for (int favored_spin = 0; favored_spin <= spin; favored_spin++) {
+      // Loop over samples to generate statistics and fill counts
+
+      for (int sample = 0; sample < num_samples; sample++) {
+        int state = sample_spin_projection(spin, valid_states[favored_spin],
+                                           polarization);
+        // Take into account step-size of 2 between states
+        int index = (state + spin) / 2;
+        counts[index]++;
+      }
+      // Check that sum of all counts coincides with num_samples
+      int sum_counts = std::accumulate(counts.begin(), counts.end(), 0);
+      VERIFY(sum_counts == num_samples);
+
+      // Check that the favored probability is set correctly
+      double probability =
+          static_cast<double>(counts[favored_spin]) / num_samples;
+      VERIFY(std::abs(probability - favored_probability) < precision);
+
+      // Check that all other probabilities coincide with the disfavored
+      // probability
+      bool are_other_probabilities_disfavored =
+          check_other_elements_than_given_index(counts, favored_spin,
+                                                disfavored_probability,
+                                                num_samples, precision);
+      VERIFY(are_other_probabilities_disfavored);
+
+      // Reset counts for next favored spin index
+      counts.assign(counts.size(), 0);
+    }
+  }
+}
+
+TEST(spin_sampling_invalid_initialization) {
+  // Invalid spin
+  for (int i = -1; i > -20; i--) {
+    try {
+      sample_spin_projection(-1, -1, 0.1);
+      std::cout << "Value Error: sample_spin_projection() unexpectedly passed "
+                << "with negative spin" << std::endl;
+    } catch (std::invalid_argument &e) {
+      // Exception was caught as expected
+    }
+  }
+
+  // favored_spin_projection out of range
+  for (int spin = 0; spin < 10; spin++) {
+    for (int favored_spin = spin + 1; favored_spin < 20; favored_spin++) {
+      try {
+        sample_spin_projection(spin, favored_spin, 0.1);
+        std::cout
+            << "Value Error: sample_spin_projection() unexpectedly passed "
+            << "with favored_spin_projection out of range" << std::endl;
+      } catch (std::invalid_argument &e) {
+        // Exception was caught as expected
+      }
+    }
+  }
+
+  // polarization_percentage larger than overall probability for spin > 0
+  for (int spin = 1; spin < 7; spin++) {
+    double max_polarization = static_cast<double>(spin);
+    for (double polarization = max_polarization + 0.1;
+         polarization <= max_polarization + 1.0; polarization += 0.1) {
+      try {
+        sample_spin_projection(spin, spin, polarization);
+        std::cout
+            << "Value Error: sample_spin_projection() unexpectedly passed "
+            << "with polarization exceeding the maximum possible" << std::endl;
+      } catch (std::invalid_argument &e) {
+        // Exception was caught as expected
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds two new keys to the config:
- `sample_spin` 
- `polarization`

which allow to sample and set spin projections on the freezeout surface, given a `polarization`. If the sampler needs to be tested with spin sampling, make sure to use SMASH-devel until the next release of both codes, as spin will be included in the next SMASH release together with the sampler

Additionally, this PR adds more unit tests for gen.cpp, especially all spin functions