### PR TITLE
Disable ROOT output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :left_right_arrow: ROOT output is now disabled by default, it can be enabled in the config by setting createRootOutput parameter to 1
+
 ## SMASH-hadron-sampler-3.1
 Date: 2023-02-29
 

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -12,6 +12,7 @@ extern int NEVENTS ;
 extern double NBINS, QMAX ;
 extern double dx, dy, deta ;
 extern double ecrit, cs2, ratio_pressure_energydensity ;
+extern bool createRootOutput;
 
 // ---- rooutines ----
 void readParams(char* filename) ;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,20 +53,24 @@ int main(int argc, char **argv)
  sprintf(sbuffer,"mkdir -p %s",sSpectraDir) ;
  system(sbuffer) ;
 
- // Initialize ROOT output
- sprintf(sbuffer, "%s/%i.root",sSpectraDir,prefix) ;
- TFile *outputFile = new TFile(sbuffer, "RECREATE");
- outputFile->cd();
- MyTree *treeIni = new MyTree(static_cast<const char*>("treeini")) ;
-
  gen::generate() ; // one call for NEVENTS
-
- // Write ROOT output
- for(int iev=0; iev<NEVENTS; iev++){
- treeIni->fill(iev) ;
- } // end events loop
- outputFile->Write() ;
- outputFile->Close() ;
+ 
+ // ROOT output disabled by default
+ if (params::createRootOutput) {
+ 
+   // Initialize ROOT output
+   sprintf(sbuffer, "%s/%i.root",sSpectraDir,prefix) ;
+   TFile *outputFile = new TFile(sbuffer, "RECREATE");
+   outputFile->cd();
+   MyTree *treeIni = new MyTree(static_cast<const char*>("treeini")) ;
+ 
+   // Write ROOT output
+   for(int iev=0; iev<NEVENTS; iev++){
+   treeIni->fill(iev) ;
+   } // end events loop
+   outputFile->Write() ;
+   outputFile->Close() ;
+ }
 
  // Write Oscar output
  write_oscar_output();

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -22,6 +22,7 @@ double dx, dy, deta ;
 double ecrit ;
 double cs2=0.15;
 double ratio_pressure_energydensity=0.15;
+bool createRootOutput {false};
 
 // ############ reading and processing the parameters
 
@@ -47,6 +48,7 @@ void readParams(char* filename)
 		else if(strcmp(parName,"ecrit")==0) ecrit = atof(parValue) ;
 		else if(strcmp(parName,"cs2")==0) cs2 = atof(parValue) ;
 		else if(strcmp(parName,"ratio_pressure_energydensity")==0) ratio_pressure_energydensity = atof(parValue) ;
+		else if(strcmp(parName,"createRootOutput")==0) createRootOutput = atoi(parValue) ;
 		else if(parName[0]=='!') cout << "CCC " << sline.str() << endl ;
 		else cout << "UUU " << sline.str() << endl ;
 	}
@@ -68,6 +70,7 @@ void printParameters()
   cout << "q_max = " << QMAX << endl ;
   cout << "cs2 = " << cs2 << endl ;
   cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity << endl ;
+  cout << "createRootOutput = " << createRootOutput << endl ;
   cout << "======= end parameters =======\n" ;
 }
 


### PR DESCRIPTION
As no longer used by principal users of the sampler, ROOT output is disabled by default in order to minimize the number of output files.