### PR TITLE
Enable ROOT thread safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :sos: Fix problems with thread safety from ROOT objects
+
 ## SMASH-hadron-sampler-3.1
 Date: 2023-02-29
 

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -3,7 +3,7 @@
 #include <TRandom3.h>
 #include <TF1.h>
 #include <fstream>
-
+#include <TROOT.h>
 #include "const.h"
 #include "gen.h"
 #include "params.h"
@@ -84,6 +84,7 @@ double totalDensity ; // sum of all thermal densities
 // ######## load the elements
 void load(char *filename, int N)
 {
+ ROOT::EnableThreadSafety();  
  double vEff=0.0, vEffOld=0.0, dvEff, dvEffOld ;
  int nfail=0, ncut=0 ;
  TLorentzVector dsigma ;
@@ -206,6 +207,7 @@ double ffthermal(double *x, double *par)
 
 int generate()
 {
+ ROOT::EnableThreadSafety();
  const double gmumu [4] = {1., -1., -1., -1.} ;
  TF1 *fthermal = new TF1("fthermal",ffthermal,0.0,10.0,4) ;
  TLorentzVector mom ;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <TFile.h>
 #include <TRandom3.h>
-
+#include <TROOT.h>
 #include <fstream>
 
 #include "gen.h"
@@ -29,6 +29,7 @@ extern "C"{
 
 int main(int argc, char **argv)
 {
+  ROOT::EnableThreadSafety();
   // command-line parameters
   int prefix = readCommandLine(argc, argv) ;
   params::printParameters() ;


### PR DESCRIPTION
While using the hadron sampler with hyperthreading, sporadic failures appeared. This seems to originate from ROOT, as ROOT is by default not thread safe. This has to be enforced explicitly.