### PR TITLE
Fix bracket bug in if statement and smash link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Please note that only tagged versions are guaranteed to be compatible with SMASH
 
 ### Install instructions:
 It is expected that the output of this sampler is used in combination with the SMASH transport model. We therefore assume SMASH was already compiled and is available to be used as an external library. All necessary prerequisites are also assumed to already be installed.
-If not, install instructions can be found [here](https://github.com/smash-transport/smash-devel/blob/master/README.md).
+If not, install instructions can be found [here](https://github.com/smash-transport/smash/blob/main/README.md).
 
 To compile the project, first set the environment variable to the smash directory:
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,14 +91,8 @@ int readCommandLine(int argc, char** argv)
 	  prefix = atoi(argv[2]) ;
 	  cout << "events mode, prefix = " << prefix << endl ;
 	  params::readParams(argv[3]) ;
-    }else if(strcmp(argv[1],"fmax")==0){
-	  if(static_cast<int>(argv[2][0]<58)){
-		prefix = atoi(argv[2]) ;
-		cout << "fmax mode, prefix = " << prefix << endl ;
-		params::readParams(argv[3]) ;
-	  }else
-	  params::readParams(argv[2]) ;
-	}else{cout << "unknown command-line switch: " << argv[1] << endl ; exit(1) ;}
+  }
+  else{cout << "unknown command-line switch: " << argv[1] << endl ; exit(1) ;}
 	return prefix ;
 }
 


### PR DESCRIPTION
I noticed a bracket bug in an if statement in main.cpp ([line 95](https://github.com/smash-transport/smash-hadron-sampler/blob/cacacacf8fff4334791a4e25fd09346b0835c0bb/src/main.cpp#L95)): `if(static_cast<int>(argv[2][0]<58)){`
The first closing bracket should be in front of `<58` if I'm not mistaken, like this: `if(static_cast<int>(argv[2][0])<58){`
If I understand the code correctly, this checks if the leading digit of the random number _NUM_ is smaller than 9, right? So it's just a check if a number is provided or why is this implemented? Do you have any insights on this, @yukarpenko?

And at the same time, I updated the smash link from smash-devel to the public smash version (as Renan did in #24) and hope that the merging will work this time.