### PR TITLE
Add example config and explanations to repo, and remove unnecessary variables from sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,16 @@ This sampler is meant to be applied in hybrid models, simulating heavy-ion colli
 
 When using the smash-hadron-sampler, please cite:
 - [I. Karpenko et al., Phys.Rev.C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339)
-- [A. Schäfer el al., arXiv:2112.08724](https://arxiv.org/abs/2112.08724).
+- [A. Schäfer et al., arXiv:2112.08724](https://arxiv.org/abs/2112.08724).
+
 
 ### Prerequisites:
 - [cmake](https://cmake.org) version &ge; 3.15.4
-- [SMASH](https://github.com/smash-transport/smash) version 3.1, as well as prerequisites therein
+- [SMASH](https://github.com/smash-transport/smash) version 3.2, as well as prerequisites therein
 - [ROOT](https://root.cern.ch) version &ge; 6.06
 
 Please note that only tagged versions are guaranteed to be compatible with SMASH.
+
 
 ### Install instructions:
 It is expected that the output of this sampler is used in combination with the SMASH transport model. We therefore assume SMASH was already compiled and is available to be used as an external library. All necessary prerequisites are also assumed to already be installed.
@@ -30,9 +32,9 @@ Execute the following commands to build the project:
 
     mkdir build
     cd build
-    cmake .. -DPythia_CONFIG_EXECUTABLE=[...]/pythia8310/bin/pythia8-config
+    cmake .. -DPythia_CONFIG_EXECUTABLE=[...]/pythia8312/bin/pythia8-config
     make
-where `[...]/pythia8310` is the path to the pythia directory to which also SMASH is coupled.
+where `[...]/pythia8312` is the path to the pythia directory to which SMASH is also coupled.
 
 In continuation, the executable `sampler` is created.
 
@@ -42,4 +44,28 @@ To run the sampler, execute the following command:
 
     ./sampler events NUM PATH_TO_CONFIG_FILE
 
-where `NUM` is a random number set by the user. It can be useful to run several instances of the sampler in parallel. `PATH_TO_CONFIG_FILE` provides the path to the configuration file. Therein the location of the freezeout hypersurface file, the path to the output directory and all other necessary parameters are set.
+where `NUM` is a random number set by the user. It can be useful to run several instances of the sampler in parallel. `PATH_TO_CONFIG_FILE` provides the path to the configuration file. Therein, the location of the freezeout hypersurface file, the path to the output directory, and all other necessary parameters can be specified.
+
+
+### Config file
+The repository provides a config file `config-example`.  
+:warning: Attention: In case this config file is used, the `surface` parameter has to be set to the location of the freezeout file (instead of _/path/to/freezeout/file_) and the `spectra_dir` parameter to the desired output path (instead of _/output/path_)!  
+
+The following lists **all possible config parameters** (to read some explanations entirely scroll to the right):
+
+Mandatory parameters:
+```
+surface                       Path to the freezeout hypersurface file that gets sampled.
+spectra_dir                   Path to the output directory.
+number_of_events              Number of events that are sampled.
+ecrit                         Critical energy density at which the hydro stopped in a particular cell and the freezeout hypersurface was constructed.
+```
+
+Optional parameters:
+```
+bulk                          Enables bulk viscosity if set to 1.   Default is 0 (false).
+shear                         Enables shear viscosity if set to 1.  Default is 0 (false).
+cs2                           Velocity of sound squared.            Default is 0.15.
+ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
+createRootOutput              Enables ROOT output if set to 1.      Default is 0 (false).
+```

--- a/config-example
+++ b/config-example
@@ -1,0 +1,6 @@
+surface          /path/to/freezeout/file
+spectra_dir      /output/path
+number_of_events 1000
+shear            1
+bulk             0
+ecrit            0.5

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -1,22 +1,17 @@
 #ifndef INCLUDE_PARAMS_H_
 #define INCLUDE_PARAMS_H_
 
-namespace params{
+namespace params {
 extern char sSurface [255], sSpectraDir [255];
-extern bool weakContribution ;
-extern bool rescatter ;
-extern bool shear ;
-extern bool bulk ;
-//extern double Temp, mu_b, mu_q, mu_s ;
-extern int NEVENTS ;
-extern double NBINS, QMAX ;
-extern double dx, dy, deta ;
-extern double ecrit, cs2, ratio_pressure_energydensity ;
-extern bool createRootOutput;
+extern bool bulk, createRootOutput, shear;
+extern int NEVENTS;
+extern double dx, dy, deta;
+extern double ecrit, cs2, ratio_pressure_energydensity;
+//extern double Temp, mu_b, mu_q, mu_s;
 
-// ---- rooutines ----
-void readParams(char* filename) ;
-void printParameters() ;
+// ---- Routines ----
+void readParams(char* filename);
+void printParameters();
 }
 
 #endif // INCLUDE_PARAMS_H_

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -8,21 +8,14 @@
 
 using namespace std ;
 
-namespace params{
+namespace params {
 
 char sSurface [255], sSpectraDir [255];
-bool weakContribution ;
-bool rescatter ;
-bool shear ;
-bool bulk ;
+bool bulk{false}, createRootOutput{false}, shear{false};
+int NEVENTS;
+double dx{0}, dy{0}, deta{0.05};
+double ecrit, cs2{0.15}, ratio_pressure_energydensity{0.15};
 //double Temp, mu_b, mu_q, mu_s ;
-int NEVENTS ;
-double NBINS, QMAX ;
-double dx, dy, deta ;
-double ecrit ;
-double cs2=0.15;
-double ratio_pressure_energydensity=0.15;
-bool createRootOutput {false};
 
 // ############ reading and processing the parameters
 
@@ -38,11 +31,7 @@ void readParams(char* filename)
 		sline >> parName >> parValue ;
 		if     (strcmp(parName,"surface")==0) strcpy(sSurface, parValue) ;
 		else if(strcmp(parName,"spectra_dir")==0) strcpy(sSpectraDir, parValue) ;
-		else if(strcmp(parName,"Nbins")==0) NBINS = atoi(parValue) ;
-		else if(strcmp(parName,"q_max")==0) QMAX = atof(parValue) ;
 		else if(strcmp(parName,"number_of_events")==0) NEVENTS = atoi(parValue) ;
-		else if(strcmp(parName,"rescatter")==0) rescatter = atoi(parValue) ;
-		else if(strcmp(parName,"weakContribution")==0) weakContribution = atoi(parValue) ;
 		else if(strcmp(parName,"shear")==0) shear = atoi(parValue) ;
 		else if(strcmp(parName,"bulk")==0) bulk = atoi(parValue) ;
 		else if(strcmp(parName,"ecrit")==0) ecrit = atof(parValue) ;
@@ -52,22 +41,17 @@ void readParams(char* filename)
 		else if(parName[0]=='!') cout << "CCC " << sline.str() << endl ;
 		else cout << "UUU " << sline.str() << endl ;
 	}
- deta=0.05 ; dx=dy=0.0 ; // TODO!
 }
 
 void printParameters()
 {
-  cout << "====== parameters ======\n" ;
+  cout << "======= parameters ===========\n" ;
   cout << "surface = " << sSurface << endl ;
   cout << "spectraDir = " << sSpectraDir << endl ;
   cout << "numberOfEvents = " << NEVENTS << endl ;
-  cout << "isRescatter = " << rescatter << endl ;
-  cout << "weakContribution = " << weakContribution << endl ;
   cout << "shear_visc_on = " << shear << endl ;
   cout << "bulk_visc_on = " << bulk << endl ;
   cout << "e_critical = " << ecrit << endl ;
-  cout << "Nbins = " << NBINS << endl ;
-  cout << "q_max = " << QMAX << endl ;
   cout << "cs2 = " << cs2 << endl ;
   cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity << endl ;
   cout << "createRootOutput = " << createRootOutput << endl ;


### PR DESCRIPTION
This PR closes issue #22.                                                                                                                                                                                                                
 
 
### What I did
- Add an example config file to the repo
- Explain config possibilities in README.md, bump smash and pythia versions (since commit 6e8b765 made smash-3.2 necessary), and fix a few typos
- Remove obsolete variables `NBINS`, `QMAX`, `rescatter`, and `weakContribution` which were initialized but never used in the code
 
 
### What I tested
- Ran sampler once with the provided `config-example` file and encountered no issues
 
@yukarpenko, I restructured a bit of code in _src/params.cpp_ and there was a `// TODO!` comment after `deta=0.05 ; dx=dy=0.0 ;` which was removed in the process. Since this comment was more than 10 years old, I assume this is not relevant anyway. Please correct me if I'm wrong and I'll re-introduce.