### PR TITLE
Add functionality to read parameters from command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :left_right_arrow: Renamed config key `spectra_dir`, used to specify the output directory, to `output_dir`
 * :left_right_arrow: Changed the command line parameters used to run the sampler to clarify their usage.
-* :heavy_plus_sign: Added optional command line parameters to overwrite the `surface` and `spectra_dir` keys in the config file.
+* :heavy_plus_sign: Added optional command line parameters to overwrite the `surface` and `output_dir` keys in the config file.
 * :sos: Fix problems with thread safety from ROOT objects
 * :left_right_arrow: ROOT output is now disabled by default, it can be enabled in the config by setting createRootOutput parameter to 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :left_right_arrow: Changed the command line parameters used to run the sampler to clarify their usage.
+* :heavy_plus_sign: Added optional command line parameters to overwrite the `surface` and `spectra_dir` keys in the config file.
 * :sos: Fix problems with thread safety from ROOT objects
 * :left_right_arrow: ROOT output is now disabled by default, it can be enabled in the config by setting createRootOutput parameter to 1
 

--- a/README.md
+++ b/README.md
@@ -57,21 +57,21 @@ All possible command line parameters are:
     -s, --surface <file>        Optional parameter to overwrite the hypersurface freezeout
                                 file given by "surface" in the config file.
     -o, --output <directory>    Optional parameter to overwrite the output directory given
-                                by "spectra_dir" in the config file.
+                                by "output_dir" in the config file.
 
 Example usage: `./sampler --config /path/to/config-example --num 1 --surface /path/to/freezeout.dat --output /path/to/output/dir`
 
 
 ### Config file
-The repository provides a config file `config-example`.  
-:warning: Attention: In case this config file is used, the `surface` parameter has to be set to the location of the freezeout file and the `spectra_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!  
+The repository provides a config file `config-example`.
+:warning: Attention: In case this config file is used, the `surface` parameter has to be set to the location of the freezeout file and the `output_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!
 
 The following lists **all possible config parameters**:
 
 Mandatory parameters:
 
     surface                       Path to the freezeout hypersurface file that gets sampled.
-    spectra_dir                   Path to the output directory.
+    output_dir                    Path to the output directory.
     number_of_events              Number of events that are sampled.
     ecrit                         Critical energy density at which the hydro stopped in a
                                   particular cell and the freezeout hypersurface was constructed.

--- a/README.md
+++ b/README.md
@@ -42,30 +42,45 @@ In continuation, the executable `sampler` is created.
 ### Execute the sampler
 To run the sampler, execute the following command:
 
-    ./sampler events NUM PATH_TO_CONFIG_FILE
+    ./sampler --config <file>
 
-where `NUM` is a random number set by the user. It can be useful to run several instances of the sampler in parallel. `PATH_TO_CONFIG_FILE` provides the path to the configuration file. Therein, the location of the freezeout hypersurface file, the path to the output directory, and all other necessary parameters can be specified.
+where `<file>` needs to be the path of the configuration file.
+In this config file the location of the freezeout hypersurface file, the path to the output directory, and all other necessary parameters can be specified.
+
+There are additional command line parameters with which the hypersurface freezeout file, the output directory, and a number prefix for parallel runs can be specified.
+All possible command line parameters are:
+
+    -c, --config <file>         Mandatory parameter to specify the config file.
+    -n, --num <integer>         Optional number to create a random seed, useful to run several
+                                instances of the sampler in parallel. The number is also the
+                                ROOT output filename.
+    -s, --surface <file>        Optional parameter to overwrite the hypersurface freezeout
+                                file given by "surface" in the config file.
+    -o, --output <directory>    Optional parameter to overwrite the output directory given
+                                by "spectra_dir" in the config file.
+
+Example usage: `./sampler --config /path/to/config-example --num 1 --surface /path/to/freezeout.dat --output /path/to/output/dir`
 
 
 ### Config file
 The repository provides a config file `config-example`.  
-:warning: Attention: In case this config file is used, the `surface` parameter has to be set to the location of the freezeout file (instead of _/path/to/freezeout/file_) and the `spectra_dir` parameter to the desired output path (instead of _/output/path_)!  
+:warning: Attention: In case this config file is used, the `surface` parameter has to be set to the location of the freezeout file and the `spectra_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!  
 
-The following lists **all possible config parameters** (to read some explanations entirely scroll to the right):
+The following lists **all possible config parameters**:
 
 Mandatory parameters:
-```
-surface                       Path to the freezeout hypersurface file that gets sampled.
-spectra_dir                   Path to the output directory.
-number_of_events              Number of events that are sampled.
-ecrit                         Critical energy density at which the hydro stopped in a particular cell and the freezeout hypersurface was constructed.
-```
+
+    surface                       Path to the freezeout hypersurface file that gets sampled.
+    spectra_dir                   Path to the output directory.
+    number_of_events              Number of events that are sampled.
+    ecrit                         Critical energy density at which the hydro stopped in a
+                                  particular cell and the freezeout hypersurface was constructed.
+
 
 Optional parameters:
-```
-bulk                          Enables bulk viscosity if set to 1.   Default is 0 (false).
-shear                         Enables shear viscosity if set to 1.  Default is 0 (false).
-cs2                           Velocity of sound squared.            Default is 0.15.
-ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
-createRootOutput              Enables ROOT output if set to 1.      Default is 0 (false).
-```
+
+    bulk                          Enables bulk viscosity if set to 1.   Default is 0 (false).
+    shear                         Enables shear viscosity if set to 1.  Default is 0 (false).
+    cs2                           Velocity of sound squared.            Default is 0.15.
+    ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
+    createRootOutput              Enables ROOT output if set to 1.      Default is 0 (false).

--- a/config-example
+++ b/config-example
@@ -1,5 +1,5 @@
 surface          /path/to/freezeout/file
-spectra_dir      /output/path
+output_dir       /output/path
 number_of_events 1000
 shear            1
 bulk             0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,16 +55,16 @@ int main(int argc, char **argv)
  system(sbuffer) ;
 
  gen::generate() ; // one call for NEVENTS
- 
+
  // ROOT output disabled by default
  if (params::createRootOutput) {
- 
+
    // Initialize ROOT output
    sprintf(sbuffer, "%s/%i.root",sSpectraDir,prefix) ;
    TFile *outputFile = new TFile(sbuffer, "RECREATE");
    outputFile->cd();
    MyTree *treeIni = new MyTree(static_cast<const char*>("treeini")) ;
- 
+
    // Write ROOT output
    for(int iev=0; iev<NEVENTS; iev++){
    treeIni->fill(iev) ;
@@ -82,18 +82,41 @@ int main(int argc, char **argv)
  return 0;
 }
 
-
-int readCommandLine(int argc, char** argv)
-{
-	if(argc==1){cout << "NO PARAMETERS, exit" << endl ; exit(1) ;}
-	int prefix = 0 ;
-	if(strcmp(argv[1],"events")==0){
-	  prefix = atoi(argv[2]) ;
-	  cout << "events mode, prefix = " << prefix << endl ;
-	  params::readParams(argv[3]) ;
+int readCommandLine(int argc, char **argv) {
+  if (argc == 1) {
+    cout << "NO PARAMETERS, exit" << endl;
+    exit(1);
   }
-  else{cout << "unknown command-line switch: " << argv[1] << endl ; exit(1) ;}
-	return prefix ;
+  bool is_config_given = false;
+  int prefix = 0;
+  int iarg = 1;
+  while (iarg < argc - 1) {
+    if (strcmp(argv[iarg], "--num") == 0 || strcmp(argv[iarg], "-n") == 0) {
+      prefix = atoi(argv[iarg + 1]);
+      iarg += 2;
+    } else if (strcmp(argv[iarg], "--config") == 0 ||
+               strcmp(argv[iarg], "-c") == 0) {
+      params::readParams(argv[iarg + 1]);
+      is_config_given = true;
+      iarg += 2;
+    } else if (strcmp(argv[iarg], "--surface") == 0 ||
+               strcmp(argv[iarg], "-s") == 0) {
+      strcpy(sSurface, argv[iarg + 1]);
+      iarg += 2;
+    } else if (strcmp(argv[iarg], "--output") == 0 ||
+               strcmp(argv[iarg], "-o") == 0) {
+      strcpy(sSpectraDir, argv[iarg + 1]);
+      iarg += 2;
+    } else {
+      cout << "Unknown command line parameter: " << argv[iarg] << endl;
+      iarg++;
+    }
+  }
+  if (!is_config_given) {
+    cout << "ERROR: No config file provided." << endl;
+    exit(126);
+  }
+  return prefix;
 }
 
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -30,7 +30,7 @@ void readParams(char* filename)
 		istringstream sline (line) ;
 		sline >> parName >> parValue ;
 		if     (strcmp(parName,"surface")==0) strcpy(sSurface, parValue) ;
-		else if(strcmp(parName,"spectra_dir")==0) strcpy(sSpectraDir, parValue) ;
+		else if(strcmp(parName,"output_dir")==0) strcpy(sSpectraDir, parValue) ;
 		else if(strcmp(parName,"number_of_events")==0) NEVENTS = atoi(parValue) ;
 		else if(strcmp(parName,"shear")==0) shear = atoi(parValue) ;
 		else if(strcmp(parName,"bulk")==0) bulk = atoi(parValue) ;
@@ -47,7 +47,7 @@ void printParameters()
 {
   cout << "======= parameters ===========\n" ;
   cout << "surface = " << sSurface << endl ;
-  cout << "spectra_dir = " << sSpectraDir << endl ;
+  cout << "output_dir = " << sSpectraDir << endl ;
   cout << "number_of_events = " << NEVENTS << endl ;
   cout << "shear_visc_on = " << shear << endl ;
   cout << "bulk_visc_on = " << bulk << endl ;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -47,11 +47,11 @@ void printParameters()
 {
   cout << "======= parameters ===========\n" ;
   cout << "surface = " << sSurface << endl ;
-  cout << "spectraDir = " << sSpectraDir << endl ;
-  cout << "numberOfEvents = " << NEVENTS << endl ;
+  cout << "spectra_dir = " << sSpectraDir << endl ;
+  cout << "number_of_events = " << NEVENTS << endl ;
   cout << "shear_visc_on = " << shear << endl ;
   cout << "bulk_visc_on = " << bulk << endl ;
-  cout << "e_critical = " << ecrit << endl ;
+  cout << "ecrit = " << ecrit << endl ;
   cout << "cs2 = " << cs2 << endl ;
   cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity << endl ;
   cout << "createRootOutput = " << createRootOutput << endl ;


### PR DESCRIPTION
As mentioned in issue #29, this introduces new command line parameters.

### What I did
- Removed "events" output mode since it's the only mode left and hence redundant
- Refactored `NUM` into `--num <integer>`
- Added the option to overwrite the hydro surface given in the config by the command line parameter  `--surface <file>` (or short `-s <file>`)
- Added the option to overwrite the output directory given in the config by the command line parameter  `--output <directory>` (or short `-o <directory>`)
- Additionally, I changed some of the parameters written to the terminal in _src/params.cpp_ to make them equal to their config keys

All this is also mentioned in README.md (apart from the last bullet point).

### What I tested
- Ran the sampler with all the different possible command line parameters mentioned above (not alone, but mixtures of them) and encountered no issues

> [!IMPORTANT]
> ~~I'm not assigning anyone yet because the changes in commit 6e8b765 (which make smash-3.2 necessary) apparently broke something and the sampler executable does not work (at least for me). I'm investigating and might open an issue about this soon. In principle my changes can be tested if the change of commit 6e8b765 is reverted and the sampler is run using smash-3.1. Since this is not ideal, I'd rather wait for the fix to test and merge this PR.~~
> EDIT: My mistake, I caused the mess up. Everything is working!

@yukarpenko, you could already check if you're happy with these new command line parameters though.

Ready for review now. @yukarpenko and @NGoetz, could you check that everything works as it should?