### PR TITLE
Change path variables to std::string variables and add .gitignore and .mailmap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+#
+# NOTE! Don't add files that are generated in specific
+# subdirectories here. Add them in the ".gitignore" file
+# in that subdirectory instead.
+#
+#
+# Top-level build directory
+#
+*~
+build*
+cmake*
+.directory
+.push_default
+*.diff
+*.orig
+*.rej
+.DS_Store
+.vscode
+.cproject
+.project
+.settings/
+__pycache__/
+
+# Convenience directory for your own files that should not be tracked
+tmp

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,21 @@
+Anna Schäfer <aschaefer@fias.uni-frankfurt.de>
+Anna Schäfer <aschaefer@fias.uni-frankfurt.de> <36138176+akschaefer@users.noreply.github.com>
+Iurii Karpenko <karpenko@fjfi.cvut.cz>
+Iurii Karpenko <karpenko@fjfi.cvut.cz> <karpeiur@cvut.cz>
+Iurii Karpenko <karpenko@fjfi.cvut.cz> <karpenko@fi.infn.it>
+Iurii Karpenko <karpenko@fjfi.cvut.cz> <yu.karpenko@gmail.com>
+Iurii Karpenko <karpenko@fjfi.cvut.cz> <karpenko@subatech.in2p3.fr>
+Iurii Karpenko <karpenko@fjfi.cvut.cz> <karpenko@fias.uni-frankfurt.de>
+Niklas Götz <goetz@itp.uni-frankfurt.de>
+Niklas Götz <goetz@itp.uni-frankfurt.de> <goetz@fias.uni-frankfurt.de>
+Niklas Götz <goetz@itp.uni-frankfurt.de> <goetz.niklas@googlemail.com>
+Nils Saß <nsass@itp.uni-frankfurt.de>
+Nils Saß <nsass@itp.uni-frankfurt.de> <nsass@fias.uni-frankfurt.de>
+Nils Saß <nsass@itp.uni-frankfurt.de> <90659054+nilssass@users.noreply.github.com>
+Renan Hirayama <hirayama@itp.uni-frankfurt.de>
+Renan Hirayama <hirayama@itp.uni-frankfurt.de> <hirayama@fias.uni-frankfurt.de>
+Renan Hirayama <hirayama@itp.uni-frankfurt.de> <rhirayam@lxbk1131.gsi.de>
+Robin Sattler <sattler@itp.uni-frankfurt.de>
+Zuzana Paulinyova <zuzana.paulinyova@upjs.sk>
+Zuzana Paulinyova <zuzana.paulinyova@upjs.sk> <paulinyova@fias.uni-frankfurt.de>
+Zuzana Paulinyova <zuzana.paulinyova@upjs.sk> <103072930+zpauliny@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
-* :left_right_arrow: Renamed config key `spectra_dir`, used to specify the output directory, to `output_dir`
+* :left_right_arrow: Renamed config key `spectra_dir`, used to specify the output directory, to `output_dir`.
 * :left_right_arrow: Changed the command line parameters used to run the sampler to clarify their usage.
 * :heavy_plus_sign: Added optional command line parameters to overwrite the `surface` and `output_dir` keys in the config file.
 * :sos: Fix problems with thread safety from ROOT objects

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In continuation, the executable `sampler` is created.
 
 
 ### Execute the sampler
-To run the sampler, execute the following command:
+To run the sampler, execute the following command in the `build` directory:
 
     ./sampler --config <file>
 
@@ -54,12 +54,12 @@ All possible command line parameters are:
     -n, --num <integer>         Optional number to create a random seed, useful to run several
                                 instances of the sampler in parallel. The number is also the
                                 ROOT output filename.
-    -s, --surface <file>        Optional parameter to overwrite the hypersurface freezeout
-                                file given by "surface" in the config file.
     -o, --output <directory>    Optional parameter to overwrite the output directory given
                                 by "output_dir" in the config file.
+    -s, --surface <file>        Optional parameter to overwrite the hypersurface freezeout
+                                file given by "surface" in the config file.
 
-Example usage: `./sampler --config /path/to/config-example --num 1 --surface /path/to/freezeout.dat --output /path/to/output/dir`
+Example usage: `./sampler --config /path/to/config-example --num 1 --output /path/to/output/dir --surface /path/to/freezeout.dat`
 
 
 ### Config file
@@ -82,6 +82,6 @@ Optional parameters:
 
     bulk                          Enables bulk viscosity if set to 1.   Default is 0 (false).
     shear                         Enables shear viscosity if set to 1.  Default is 0 (false).
-    cs2                           Velocity of sound squared.            Default is 0.15.
+    cs2                           Speed of sound squared.               Default is 0.15.
     ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
     createRootOutput              Enables ROOT output if set to 1.      Default is 0 (false).

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -87,7 +87,7 @@ double *cumulantDensity; // particle densities (thermal). Seems to be redundant,
 double totalDensity;     // sum of all thermal densities
 
 // ######## load the elements
-void load(char *filename, int N) {
+void load(const char *filename, int N) {
   ROOT::EnableThreadSafety();
   double vEff = 0.0, vEffOld = 0.0, dvEff, dvEffOld;
   int nfail = 0, ncut = 0;

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -172,7 +172,7 @@ void load(char *filename, int N) {
     // ########################
     // pi^{mu nu} boost to fluid rest frame
     // ########################
-    if (params::shear) {
+    if (params::shear_viscosity_enabled) {
       double _pi[10], boostMatrix[4][4];
       fillBoostMatrix(-surf[n].u[1] / surf[n].u[0],
                       -surf[n].u[2] / surf[n].u[0],
@@ -189,7 +189,7 @@ void load(char *filename, int N) {
         surf[n].pi[i] = _pi[i];
     } // end pi boost
   }
-  if (params::shear)
+  if (params::shear_viscosity_enabled)
     dsigmaMax *= 2.0; // *2.0: jun17. default: *1.5
   else
     dsigmaMax *= 1.3;
@@ -343,7 +343,7 @@ int generate() {
                surf[iel].dsigma[3] * mom.Pz()) /
               mom.E();
           double WviscFactor = 1.0;
-          if (params::shear) {
+          if (params::shear_viscosity_enabled) {
             const double feq =
                 C_Feq /
                 (exp((sqrt(p * p + mass * mass) - muf) / surf[iel].T) - stat);
@@ -359,16 +359,16 @@ int generate() {
                  (params::ecrit +
                   params::ecrit * params::ratio_pressure_energydensity));
           }
-          if (params::bulk) {
+          if (params::bulk_viscosity_enabled) {
             const double feq =
                 C_Feq /
                 (exp((sqrt(p * p + mass * mass) - muf) / surf[iel].T) - stat);
             WviscFactor -=
                 (1.0 + stat * feq) * surf[iel].Pi *
                 (mass * mass / (3 * mom.E()) -
-                 mom.E() * (1.0 / 3.0 - params::cs2)) /
-                (15 * (1.0 / 3.0 - params::cs2) * (1.0 / 3.0 - params::cs2) *
-                 surf[iel].T *
+                 mom.E() * (1.0 / 3.0 - params::speed_of_sound_squared)) /
+                (15 * (1.0 / 3.0 - params::speed_of_sound_squared) *
+                 (1.0 / 3.0 - params::speed_of_sound_squared) * surf[iel].T *
                  (params::ecrit +
                   params::ecrit * params::ratio_pressure_energydensity));
           }

--- a/src/include/gen.h
+++ b/src/include/gen.h
@@ -19,7 +19,7 @@ extern int *npart;
 const int NPartBuf = 30000; // dimension of particle buffer for each event
 
 // functions
-void load(char *filename, int N);
+void load(const char *filename, int N);
 int generate();
 } // namespace gen
 

--- a/src/include/oscaroutput.h
+++ b/src/include/oscaroutput.h
@@ -11,7 +11,7 @@
 
 void write_oscar_output() {
   // initialize Oscar output
-  const std::filesystem::path OutputPath = params::sSpectraDir;
+  const std::filesystem::path OutputPath = params::output_directory;
   std::unique_ptr<smash::OutputInterface> OscarOutput = create_oscar_output(
       "Oscar2013", "Particles", OutputPath, smash::OutputParameters());
 

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -2,11 +2,11 @@
 #define INCLUDE_PARAMS_H_
 
 namespace params {
-extern char sSurface[255], sSpectraDir[255];
-extern bool bulk, createRootOutput, shear;
+extern char surface_file[255], output_directory[255];
+extern bool bulk_viscosity_enabled, createRootOutput, shear_viscosity_enabled;
 extern int NEVENTS;
 extern double dx, dy, deta;
-extern double ecrit, cs2, ratio_pressure_energydensity;
+extern double ecrit, speed_of_sound_squared, ratio_pressure_energydensity;
 // extern double Temp, mu_b, mu_q, mu_s;
 
 // ---- Routines ----

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -1,8 +1,10 @@
 #ifndef INCLUDE_PARAMS_H_
 #define INCLUDE_PARAMS_H_
 
+#include <string>
+
 namespace params {
-extern char surface_file[255], output_directory[255];
+extern std::string surface_file, output_directory;
 extern bool bulk_viscosity_enabled, createRootOutput, shear_viscosity_enabled;
 extern int NEVENTS;
 extern double dx, dy, deta;
@@ -10,7 +12,7 @@ extern double ecrit, speed_of_sound_squared, ratio_pressure_energydensity;
 // extern double Temp, mu_b, mu_q, mu_s;
 
 // ---- Routines ----
-void readParams(char *filename);
+void readParams(const std::string &filename);
 void printParameters();
 } // namespace params
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,8 +13,8 @@ int getNlines(char *filename);
 int readCommandLine(int argc, char **argv);
 
 using params::NEVENTS;
-using params::sSpectraDir;
-using params::sSurface;
+using params::output_directory;
+using params::surface_file;
 
 int ranseed;
 
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
   gen::rnd = random3;
 
   // ========== generator init
-  gen::load(sSurface, getNlines(sSurface));
+  gen::load(surface_file, getNlines(surface_file));
 
   // ========== trees & files
   time_t start, end;
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
 
   //============= main task
   char sbuffer[255];
-  sprintf(sbuffer, "mkdir -p %s", sSpectraDir);
+  sprintf(sbuffer, "mkdir -p %s", output_directory);
   system(sbuffer);
 
   gen::generate(); // one call for NEVENTS
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
   if (params::createRootOutput) {
 
     // Initialize ROOT output
-    sprintf(sbuffer, "%s/%i.root", sSpectraDir, prefix);
+    sprintf(sbuffer, "%s/%i.root", output_directory, prefix);
     TFile *outputFile = new TFile(sbuffer, "RECREATE");
     outputFile->cd();
     MyTree *treeIni = new MyTree(static_cast<const char *>("treeini"));
@@ -81,28 +81,28 @@ int main(int argc, char **argv) {
 
 int readCommandLine(int argc, char **argv) {
   if (argc == 1) {
-    cout << "NO PARAMETERS, exit" << endl;
+    cout << "ERROR: Missing command line parameters!" << endl;
     exit(1);
   }
   bool is_config_given = false;
   int prefix = 0;
   int iarg = 1;
   while (iarg < argc - 1) {
-    if (strcmp(argv[iarg], "--num") == 0 || strcmp(argv[iarg], "-n") == 0) {
-      prefix = atoi(argv[iarg + 1]);
-      iarg += 2;
-    } else if (strcmp(argv[iarg], "--config") == 0 ||
-               strcmp(argv[iarg], "-c") == 0) {
+    if (strcmp(argv[iarg], "--config") == 0 || strcmp(argv[iarg], "-c") == 0) {
       params::readParams(argv[iarg + 1]);
       is_config_given = true;
       iarg += 2;
-    } else if (strcmp(argv[iarg], "--surface") == 0 ||
-               strcmp(argv[iarg], "-s") == 0) {
-      strcpy(sSurface, argv[iarg + 1]);
+    } else if (strcmp(argv[iarg], "--num") == 0 ||
+               strcmp(argv[iarg], "-n") == 0) {
+      prefix = atoi(argv[iarg + 1]);
       iarg += 2;
     } else if (strcmp(argv[iarg], "--output") == 0 ||
                strcmp(argv[iarg], "-o") == 0) {
-      strcpy(sSpectraDir, argv[iarg + 1]);
+      strcpy(output_directory, argv[iarg + 1]);
+      iarg += 2;
+    } else if (strcmp(argv[iarg], "--surface") == 0 ||
+               strcmp(argv[iarg], "-s") == 0) {
+      strcpy(surface_file, argv[iarg + 1]);
       iarg += 2;
     } else {
       cout << "Unknown command line parameter: " << argv[iarg] << endl;
@@ -120,7 +120,7 @@ int readCommandLine(int argc, char **argv) {
 int getNlines(char *filename) {
   ifstream fin(filename);
   if (!fin) {
-    cout << "getNlines: cannot open file: " << filename << endl;
+    cout << "getNlines funtion: Cannot open file " << filename << endl;
     exit(1);
   }
   string line;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <TROOT.h>
 #include <TRandom3.h>
 #include <fstream>
+#include <string>
 
 #include "gen.h"
 #include "oscaroutput.h"
@@ -9,7 +10,7 @@
 #include "tree.h"
 
 using namespace std;
-int getNlines(char *filename);
+int getNlines(const char *filename);
 int readCommandLine(int argc, char **argv);
 
 using params::NEVENTS;
@@ -39,16 +40,15 @@ int main(int argc, char **argv) {
   gen::rnd = random3;
 
   // ========== generator init
-  gen::load(surface_file, getNlines(surface_file));
+  gen::load(surface_file.c_str(), getNlines(surface_file.c_str()));
 
   // ========== trees & files
   time_t start, end;
   time(&start);
 
   //============= main task
-  char sbuffer[255];
-  sprintf(sbuffer, "mkdir -p %s", output_directory);
-  system(sbuffer);
+  std::string make_output_directory = "mkdir -p " + output_directory;
+  system(make_output_directory.c_str());
 
   gen::generate(); // one call for NEVENTS
 
@@ -56,8 +56,9 @@ int main(int argc, char **argv) {
   if (params::createRootOutput) {
 
     // Initialize ROOT output
-    sprintf(sbuffer, "%s/%i.root", output_directory, prefix);
-    TFile *outputFile = new TFile(sbuffer, "RECREATE");
+    std::string root_output_file =
+        output_directory + "/" + std::to_string(prefix) + ".root";
+    TFile *outputFile = new TFile(root_output_file.c_str(), "RECREATE");
     outputFile->cd();
     MyTree *treeIni = new MyTree(static_cast<const char *>("treeini"));
 
@@ -98,11 +99,11 @@ int readCommandLine(int argc, char **argv) {
       iarg += 2;
     } else if (strcmp(argv[iarg], "--output") == 0 ||
                strcmp(argv[iarg], "-o") == 0) {
-      strcpy(output_directory, argv[iarg + 1]);
+      output_directory = argv[iarg + 1];
       iarg += 2;
     } else if (strcmp(argv[iarg], "--surface") == 0 ||
                strcmp(argv[iarg], "-s") == 0) {
-      strcpy(surface_file, argv[iarg + 1]);
+      surface_file = argv[iarg + 1];
       iarg += 2;
     } else {
       cout << "Unknown command line parameter: " << argv[iarg] << endl;
@@ -117,7 +118,7 @@ int readCommandLine(int argc, char **argv) {
 }
 
 // auxiliary function to get the number of lines
-int getNlines(char *filename) {
+int getNlines(const char *filename) {
   ifstream fin(filename);
   if (!fin) {
     cout << "getNlines funtion: Cannot open file " << filename << endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,12 +17,6 @@ using params::NEVENTS;
 using params::output_directory;
 using params::surface_file;
 
-int ranseed;
-
-extern "C" {
-void getranseedcpp_(int *seed) { *seed = ranseed; }
-}
-
 // ########## MAIN block ##################
 
 int main(int argc, char **argv) {
@@ -32,7 +26,7 @@ int main(int argc, char **argv) {
   params::printParameters();
   time_t time0;
   time(&time0);
-  ranseed = time0 + prefix * 16;
+  int ranseed = time0 + prefix * 16;
 
   TRandom3 *random3 = new TRandom3();
   random3->SetSeed(ranseed);
@@ -73,7 +67,7 @@ int main(int argc, char **argv) {
   // Write Oscar output
   write_oscar_output();
 
-  cout << "event generation done\n";
+  cout << "Event generation done\n";
   time(&end);
   float diff2 = difftime(end, start);
   cout << "Execution time = " << diff2 << " [sec]" << endl;
@@ -121,7 +115,7 @@ int readCommandLine(int argc, char **argv) {
 int getNlines(const char *filename) {
   ifstream fin(filename);
   if (!fin) {
-    cout << "getNlines funtion: Cannot open file " << filename << endl;
+    cout << "getNlines function error: Cannot open file " << filename << endl;
     exit(1);
   }
   string line;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 namespace params {
 
-char surface_file[255], output_directory[255];
+std::string surface_file{"unset"}, output_directory{"unset"};
 bool bulk_viscosity_enabled{false}, createRootOutput{false},
     shear_viscosity_enabled{false};
 int NEVENTS;
@@ -20,36 +20,36 @@ double ecrit, speed_of_sound_squared{0.15}, ratio_pressure_energydensity{0.15};
 
 // ############ reading and processing the parameters
 
-void readParams(char *filename) {
-  char parName[255], parValue[255];
-  ifstream fin(filename);
+void readParams(const std::string &filename) {
+  std::string parName, parValue;
+  ifstream fin(filename.c_str());
   if (!fin.is_open()) {
     cout << "ERROR: Cannot open config file " << filename << endl;
     exit(1);
   }
   while (fin.good()) {
-    string line;
+    std::string line;
     getline(fin, line);
     istringstream sline(line);
     sline >> parName >> parValue;
-    if (strcmp(parName, "surface") == 0)
-      strcpy(surface_file, parValue);
-    else if (strcmp(parName, "output_dir") == 0)
-      strcpy(output_directory, parValue);
-    else if (strcmp(parName, "number_of_events") == 0)
-      NEVENTS = atoi(parValue);
-    else if (strcmp(parName, "shear") == 0)
-      shear_viscosity_enabled = atoi(parValue);
-    else if (strcmp(parName, "bulk") == 0)
-      bulk_viscosity_enabled = atoi(parValue);
-    else if (strcmp(parName, "ecrit") == 0)
-      ecrit = atof(parValue);
-    else if (strcmp(parName, "cs2") == 0)
-      speed_of_sound_squared = atof(parValue);
-    else if (strcmp(parName, "ratio_pressure_energydensity") == 0)
-      ratio_pressure_energydensity = atof(parValue);
-    else if (strcmp(parName, "createRootOutput") == 0)
-      createRootOutput = atoi(parValue);
+    if (parName == "surface")
+      surface_file = parValue;
+    else if (parName == "output_dir")
+      output_directory = parValue;
+    else if (parName == "number_of_events")
+      NEVENTS = std::stoi(parValue);
+    else if (parName == "shear")
+      shear_viscosity_enabled = std::stoi(parValue);
+    else if (parName == "bulk")
+      bulk_viscosity_enabled = std::stoi(parValue);
+    else if (parName == "ecrit")
+      ecrit = std::stod(parValue);
+    else if (parName == "cs2")
+      speed_of_sound_squared = std::stod(parValue);
+    else if (parName == "ratio_pressure_energydensity")
+      ratio_pressure_energydensity = std::stod(parValue);
+    else if (parName == "createRootOutput")
+      createRootOutput = std::stoi(parValue);
     else if (parName[0] == '!')
       cout << "CCC " << sline.str() << endl;
     else

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -10,11 +10,12 @@ using namespace std;
 
 namespace params {
 
-char sSurface[255], sSpectraDir[255];
-bool bulk{false}, createRootOutput{false}, shear{false};
+char surface_file[255], output_directory[255];
+bool bulk_viscosity_enabled{false}, createRootOutput{false},
+    shear_viscosity_enabled{false};
 int NEVENTS;
 double dx{0}, dy{0}, deta{0.05};
-double ecrit, cs2{0.15}, ratio_pressure_energydensity{0.15};
+double ecrit, speed_of_sound_squared{0.15}, ratio_pressure_energydensity{0.15};
 // double Temp, mu_b, mu_q, mu_s ;
 
 // ############ reading and processing the parameters
@@ -23,7 +24,7 @@ void readParams(char *filename) {
   char parName[255], parValue[255];
   ifstream fin(filename);
   if (!fin.is_open()) {
-    cout << "cannot open parameters file " << filename << endl;
+    cout << "ERROR: Cannot open config file " << filename << endl;
     exit(1);
   }
   while (fin.good()) {
@@ -32,19 +33,19 @@ void readParams(char *filename) {
     istringstream sline(line);
     sline >> parName >> parValue;
     if (strcmp(parName, "surface") == 0)
-      strcpy(sSurface, parValue);
+      strcpy(surface_file, parValue);
     else if (strcmp(parName, "output_dir") == 0)
-      strcpy(sSpectraDir, parValue);
+      strcpy(output_directory, parValue);
     else if (strcmp(parName, "number_of_events") == 0)
       NEVENTS = atoi(parValue);
     else if (strcmp(parName, "shear") == 0)
-      shear = atoi(parValue);
+      shear_viscosity_enabled = atoi(parValue);
     else if (strcmp(parName, "bulk") == 0)
-      bulk = atoi(parValue);
+      bulk_viscosity_enabled = atoi(parValue);
     else if (strcmp(parName, "ecrit") == 0)
       ecrit = atof(parValue);
     else if (strcmp(parName, "cs2") == 0)
-      cs2 = atof(parValue);
+      speed_of_sound_squared = atof(parValue);
     else if (strcmp(parName, "ratio_pressure_energydensity") == 0)
       ratio_pressure_energydensity = atof(parValue);
     else if (strcmp(parName, "createRootOutput") == 0)
@@ -58,13 +59,13 @@ void readParams(char *filename) {
 
 void printParameters() {
   cout << "======= parameters ===========\n";
-  cout << "surface = " << sSurface << endl;
-  cout << "output_dir = " << sSpectraDir << endl;
+  cout << "surface = " << surface_file << endl;
+  cout << "output_dir = " << output_directory << endl;
   cout << "number_of_events = " << NEVENTS << endl;
-  cout << "shear_visc_on = " << shear << endl;
-  cout << "bulk_visc_on = " << bulk << endl;
+  cout << "shear_visc_on = " << shear_viscosity_enabled << endl;
+  cout << "bulk_visc_on = " << bulk_viscosity_enabled << endl;
   cout << "ecrit = " << ecrit << endl;
-  cout << "cs2 = " << cs2 << endl;
+  cout << "cs2 = " << speed_of_sound_squared << endl;
   cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity
        << endl;
   cout << "createRootOutput = " << createRootOutput << endl;


### PR DESCRIPTION
This fixes #21. @NGoetz and @nilssass, it would be great if you could, apart from checking my changes, let me know if additional changes from `char` to `std::string` variables would be beneficial and if so where. One of you two reviewing and checking is enough.
@yukarpenko, it would be nice if you could have a look as well (esp. because of bullet point 4.).

### What I did
1. Add .gitignore and .mailmap files.
2. Improved variable names (listed are only the most important ones):
    - `sSurface` is now `surface_file`
    - `sSpectraDir` is now `output_dir`
    - `sbuffer` now "split" into `make_output_directory` and `root_output_file`
3. Changed path variables `surface_file` and `output_dir` as well as `sbuffer` (now `make_output_directory` and `root_output_file`) from `char` to `std::string` variables to avoid buffer overflow.
4. Removed unused `getrandseedcpp_` function in _src/main.cpp_ (seems to be a relic from earlier code versions).

### What I tested
- Compiled and ran the sampler without any issues.