### PR TITLE
Resolve compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 message(STATUS "CXX_FLAGS = " ${CMAKE_CXX_FLAGS})
 
 # Collect all the cpp files
-set(sampler_src src/gen.cpp src/params.cpp src/tree.cpp)
+set(sampler_src src/gen.cpp src/oscaroutput.cpp src/params.cpp src/tree.cpp)
 
 # Create object library for the linker which contains pre-compiled cpp files
 add_library(objlib OBJECT ${sampler_src})

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
-# Hadron Sampler
+# SMASH Hadron Sampler
 
-This sampler is meant to be applied in hybrid models, simulating heavy-ion collisions in the high temperature or baryon-density region. More precisely it provides an interface between the macroscopic hydrodynamic evolution of the fireball and the hadronic afterburner. During the hydrodynamic evolution a hypersurface of constant energy density (the switching energy density) is created. Each element on the hypersurface needs then be transformed into a list of particles with properties loosely provided by the macroscopic properties of the hypersurface elements. This process of particlization is performed by means of the hadron sampler provided within this project. It is designed to couple the [3+1D viscous hydrodynamic code vhlle](https://github.com/yukarpenko/vhlle) to the [hadronic transport model SMASH](https://smash-transport.github.io). For details about the sampling algorithm, please consult [I. Karpenko et al., Phys.Rev.C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339).
+This sampler is meant to be applied in hybrid models, simulating heavy-ion collisions in the high temperature or baryon-density region. More precisely it provides an interface between the macroscopic hydrodynamic evolution of the fireball and the hadronic afterburner. During the hydrodynamic evolution a hypersurface of constant energy density (the switching energy density) is created. Each element on the hypersurface needs then be transformed into a list of particles with properties loosely provided by the macroscopic properties of the hypersurface elements. This process of particlization is performed by means of the hadron sampler provided within this project. It is designed to couple the [3+1D viscous hydrodynamic code vhlle](https://github.com/yukarpenko/vhlle) to the [hadronic transport model SMASH](https://smash-transport.github.io). For details about the sampling algorithm, please consult [I. Karpenko et al., Phys. Rev. C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339).
 
-When using the smash-hadron-sampler, please cite:
-- [I. Karpenko et al., Phys.Rev.C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339)
-- [A. Schäfer et al., arXiv:2112.08724](https://arxiv.org/abs/2112.08724).
+> [!NOTE]
+> Please cite the following two papers when using the SMASH hadron sampler:
+> - [I. Karpenko et al., Phys. Rev. C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339)
+> - [A. Schäfer et al., arXiv:2112.08724](https://arxiv.org/abs/2112.08724)
 
 
-### Prerequisites:
+## Prerequisites
 - [cmake](https://cmake.org) version &ge; 3.15.4
 - [SMASH](https://github.com/smash-transport/smash) version 3.2, as well as prerequisites therein
 - [ROOT](https://root.cern.ch) version &ge; 6.06
 
-Please note that only tagged versions are guaranteed to be compatible with SMASH.
+> [!IMPORTANT]
+> Only tagged versions are guaranteed to be compatible with SMASH.
 
 
-### Install instructions:
+## Install instructions
 It is expected that the output of this sampler is used in combination with the SMASH transport model. We therefore assume SMASH was already compiled and is available to be used as an external library. All necessary prerequisites are also assumed to already be installed.
 If not, install instructions can be found [here](https://github.com/smash-transport/smash/blob/main/README.md).
 
@@ -39,7 +41,7 @@ where `[...]/pythia8312` is the path to the pythia directory to which SMASH is a
 In continuation, the executable `sampler` is created.
 
 
-### Execute the sampler
+## Execute the sampler
 To run the sampler, execute the following command in the `build` directory:
 
     ./sampler --config <file>
@@ -59,13 +61,12 @@ All possible command line parameters are:
     -s, --surface <file>        Optional parameter to overwrite the hypersurface freezeout
                                 file given by "surface" in the config file.
 
-Example usage: `./sampler --config /path/to/config-example --num 1 --output /path/to/output/dir --surface /path/to/freezeout.dat`
+Example usage:
+
+    ./sampler --config /path/to/config-example --num 1 --output /path/to/output/dir --surface /path/to/freezeout.dat
 
 
-### Config file
-The repository provides a config file `config-example`.
-
-:warning: Attention: In case this config file is used, the `surface` parameter has to be set to the location of the freezeout file and the `output_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!
+## Config file
 
 The following lists **all possible config parameters**:
 
@@ -85,3 +86,9 @@ Optional parameters:
     cs2                           Speed of sound squared.               Default is 0.15.
     ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
     createRootOutput              Enables ROOT output if set to 1.      Default is 0 (false).
+
+
+> [!TIP]
+> The repository provides an example config file named `config-example`.
+
+In case this example config file is used, the `surface` parameter has to be set to the location of the freezeout file and the `output_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -20,6 +20,32 @@ const double C_Feq = (pow(0.5 / M_PI / hbarC, 3));
 // #  also, pre-BOOSTED dsigma is used                      #
 // ##########################################################
 
+namespace gen {
+
+int Nelem;
+double *ntherm, dvMax, dsigmaMax;
+TRandom3 *rnd;
+int NPART;
+// const int NPartBuf = 10000 ;
+smash::ParticleData ***pList; // particle arrays
+
+struct element {
+  double tau, x, y, eta;
+  double u[4];
+  double dsigma[4];
+  double T, mub, muq, mus;
+  double pi[10];
+  double Pi;
+};
+
+element *surf;
+int *npart; // number of generated particles in each event
+
+const double c1 = pow(1. / 2. / hbarC / TMath::Pi(), 3.0);
+double *cumulantDensity; // particle densities (thermal). Seems to be redundant,
+                         // but needed for fast generation
+double totalDensity;     // sum of all thermal densities
+
 // active Lorentz boost
 void fillBoostMatrix(double vx, double vy, double vz, double boostMatrix[4][4])
 // here in boostMatrix [0]=t, [1]=x, [2]=y, [3]=z
@@ -59,32 +85,6 @@ int index44(const int &i, const int &j) {
   else
     return (j * (j + 1)) / 2 + i;
 }
-
-namespace gen {
-
-int Nelem;
-double *ntherm, dvMax, dsigmaMax;
-TRandom3 *rnd;
-int NPART;
-// const int NPartBuf = 10000 ;
-smash::ParticleData ***pList; // particle arrays
-
-struct element {
-  double tau, x, y, eta;
-  double u[4];
-  double dsigma[4];
-  double T, mub, muq, mus;
-  double pi[10];
-  double Pi;
-};
-
-element *surf;
-int *npart; // number of generated particles in each event
-
-const double c1 = pow(1. / 2. / hbarC / TMath::Pi(), 3.0);
-double *cumulantDensity; // particle densities (thermal). Seems to be redundant,
-                         // but needed for fast generation
-double totalDensity;     // sum of all thermal densities
 
 // ######## load the elements
 void load(const char *filename, int N) {
@@ -228,7 +228,7 @@ double ffthermal(double *x, double *par) {
   return x[0] * x[0] / (exp((sqrt(x[0] * x[0] + mass * mass) - mu) / T) - stat);
 }
 
-int generate() {
+void generate() {
   ROOT::EnableThreadSafety();
   const double gmumu[4] = {1., -1., -1., -1.};
   TF1 *fthermal = new TF1("fthermal", ffthermal, 0.0, 10.0, 4);
@@ -404,7 +404,6 @@ int generate() {
            << endl;
   } // loop over all elements
   cout << "therm_failed elements: " << ntherm_fail << endl;
-  return npart[0];
   delete fthermal;
 }
 

--- a/src/include/gen.h
+++ b/src/include/gen.h
@@ -8,8 +8,6 @@ class TRandom3;
 class DatabasePDG2;
 class Particle;
 
-int index44(const int &i, const int &j);
-
 namespace gen {
 // typedef std::vector<Particle*> ParticleList ; // TODO in far future
 //  data
@@ -19,8 +17,11 @@ extern int *npart;
 const int NPartBuf = 30000; // dimension of particle buffer for each event
 
 // functions
+void fillBoostMatrix(double vx, double vy, double vz, double boostMatrix[4][4]);
+void generate();
 void load(const char *filename, int N);
-int generate();
+double ffthermal(double *x, double *par);
+int index44(const int &i, const int &j);
 } // namespace gen
 
 #endif // INCLUDE_GEN_H_

--- a/src/include/oscaroutput.h
+++ b/src/include/oscaroutput.h
@@ -1,39 +1,6 @@
 #ifndef INCLUDE_OSCAROUTPUT_H_
 #define INCLUDE_OSCAROUTPUT_H_
 
-#include "smash/file.h"
-#include "smash/oscaroutput.h"
-#include "smash/outputparameters.h"
-#include "smash/particles.h"
-
-#include "gen.h"
-#include "params.h"
-
-void write_oscar_output() {
-  // initialize Oscar output
-  const std::filesystem::path OutputPath = params::output_directory;
-  std::unique_ptr<smash::OutputInterface> OscarOutput = create_oscar_output(
-      "Oscar2013", "Particles", OutputPath, smash::OutputParameters());
-
-  for (int iev = 0; iev < params::NEVENTS; iev++) {
-    // Create Particles oject which contains the full particle list of each
-    // event
-    std::unique_ptr<smash::Particles> particles =
-        std::make_unique<smash::Particles>();
-
-    for (int inpart = 0; inpart < gen::npart[iev]; inpart++) {
-      smash::ParticleData *data = gen::pList[iev][inpart];
-      particles->insert(*data);
-    }
-    // Set dummy values for event info:
-    // {impact parameter, box_length, current time, total_kinetic_energy, total
-    // mean field energy, number of test particles, empty event (no
-    // collisions?)}
-    smash::EventInfo event_info{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, false};
-    smash::EventLabel event_id{iev, 0};
-    // Write output
-    OscarOutput->at_eventend(*particles, event_id, event_info);
-  }
-}
+void write_oscar_output();
 
 #endif // INCLUDE_OSCAROUTPUT_H_

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ int readCommandLine(int argc, char **argv) {
   return prefix;
 }
 
-// auxiliary function to get the number of lines
+// auxiliary function to get the number of lines of the freezeout data file
 int getNlines(const char *filename) {
   ifstream fin(filename);
   if (!fin) {
@@ -119,11 +119,10 @@ int getNlines(const char *filename) {
     exit(1);
   }
   string line;
-  int nlines = 0;
-  while (fin.good()) {
-    getline(fin, line);
-    nlines++;
+  int number_of_lines = 0;
+  while (getline(fin, line)) {
+    number_of_lines++;
   };
   fin.close();
-  return nlines - 1;
+  return number_of_lines;
 }

--- a/src/oscaroutput.cpp
+++ b/src/oscaroutput.cpp
@@ -1,0 +1,38 @@
+#include "smash/oscaroutput.h"
+#include "smash/file.h"
+#include "smash/outputparameters.h"
+#include "smash/particles.h"
+
+#include "gen.h"
+#include "oscaroutput.h"
+#include "params.h"
+
+void write_oscar_output() {
+  // initialize Oscar output
+  const std::filesystem::path OutputPath = params::output_directory;
+  std::unique_ptr<smash::OutputInterface> OscarOutput = create_oscar_output(
+      "Oscar2013", "Particles", OutputPath, smash::OutputParameters());
+
+  for (int iev = 0; iev < params::NEVENTS; iev++) {
+    // Create Particles oject which contains the full particle list of each
+    // event
+    std::unique_ptr<smash::Particles> particles =
+        std::make_unique<smash::Particles>();
+
+    for (int inpart = 0; inpart < gen::npart[iev]; inpart++) {
+      smash::ParticleData *data = gen::pList[iev][inpart];
+      particles->insert(*data);
+    }
+    // Set dummy values for event info:
+    // {impact parameter, box_length, current_time, E_kinetic_total, total
+    // mean field energy, E_total, number of test particles, n_ensembles,
+    // !projectile_target_interact, kinematic_cut_for_SMASH_IC}
+    // See src/experiment.cc in the smash repository for more detailed
+    // information on event_info
+    smash::EventInfo event_info{0.0, 0.0, 0.0, 0.0,   0.0,
+                                0.0, 1,   0,   false, false};
+    smash::EventLabel event_id{iev, 0};
+    // Write output
+    OscarOutput->at_eventend(*particles, event_id, event_info);
+  }
+}


### PR DESCRIPTION
This fixes #35 (in combination with smash-transport/smash-devel#1362 in which @axelkrypton resolved the 3rdparty warnings).                                                                                                              
 
### What I did
- Resolved compiler warnings due to the sampler code. Part of it was that the smash struct `event_info` wasn't initialized properly. @NGoetz, it would be nice if you could double check the new initialization of it in _src/oscaroutput.cpp_.
- Some minor improvements to the code and the README file.
 
### What I tested
- Compiled and ran the sampler without any issues.