### PR TITLE
Rename keys to clarify and unify naming scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :left_right_arrow: Renamed config key `surface`, used to specify the freezeout surface file, to `surface_file` to clarify key.
 * :left_right_arrow: Renamed config key `createRootOutput`, used to enable ROOT output, to `create_root_output` to unify naming convention.
 * :left_right_arrow: Renamed config key `spectra_dir`, used to specify the output directory, to `output_dir`.
 * :left_right_arrow: Changed the command line parameters used to run the sampler to clarify their usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :left_right_arrow: Renamed config key `createRootOutput`, used to enable ROOT output, to `create_root_output` to unify naming convention.
 * :left_right_arrow: Renamed config key `spectra_dir`, used to specify the output directory, to `output_dir`.
 * :left_right_arrow: Changed the command line parameters used to run the sampler to clarify their usage.
 * :heavy_plus_sign: Added optional command line parameters to overwrite the `surface` and `output_dir` keys in the config file.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Optional parameters:
     shear                         Enables shear viscosity if set to 1.  Default is 0 (false).
     cs2                           Speed of sound squared.               Default is 0.15.
     ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
-    createRootOutput              Enables ROOT output if set to 1.      Default is 0 (false).
+    create_root_output            Enables ROOT output if set to 1.      Default is 0 (false).
 
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ All possible command line parameters are:
     -o, --output <directory>    Optional parameter to overwrite the output directory given
                                 by "output_dir" in the config file.
     -s, --surface <file>        Optional parameter to overwrite the hypersurface freezeout
-                                file given by "surface" in the config file.
+                                file given by "surface_file" in the config file.
 
 Example usage:
 
-    ./sampler --config /path/to/config-example --num 1 --output /path/to/output/dir --surface /path/to/freezeout.dat
+    ./sampler -c /path/to/config-example --num 1 --output /path/to/output/dir -s /path/to/freezeout.dat
 
 
 ## Config file
@@ -72,7 +72,7 @@ The following lists **all possible config parameters**:
 
 Mandatory parameters:
 
-    surface                       Path to the freezeout hypersurface file that gets sampled.
+    surface_file                  Path to the freezeout hypersurface file that gets sampled.
     output_dir                    Path to the output directory.
     number_of_events              Number of events that are sampled.
     ecrit                         Critical energy density at which the hydro stopped in a
@@ -91,4 +91,4 @@ Optional parameters:
 > [!TIP]
 > The repository provides an example config file named `config-example`.
 
-In case this example config file is used, the `surface` parameter has to be set to the location of the freezeout file and the `output_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!
+In case this example config file is used, the `surface_file` parameter has to be set to the location of the freezeout file and the `output_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!

--- a/config-example
+++ b/config-example
@@ -1,4 +1,4 @@
-surface          /path/to/freezeout/file
+surface_file     /path/to/freezeout/file
 output_dir       /output/path
 number_of_events 1000
 shear            1

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -11,9 +11,6 @@
 
 using namespace std;
 
-#define _USE_MATH_DEFINES
-const double C_Feq = (pow(0.5 / M_PI / hbarC, 3));
-
 // ##########################################################
 // #  this version works with arbitrary T/mu distribution   #
 // #  on freezeout hypersurface (May'2012)                  #
@@ -23,10 +20,9 @@ const double C_Feq = (pow(0.5 / M_PI / hbarC, 3));
 namespace gen {
 
 int Nelem;
+int NPART;
 double *ntherm, dvMax, dsigmaMax;
 TRandom3 *rnd;
-int NPART;
-// const int NPartBuf = 10000 ;
 smash::ParticleData ***pList; // particle arrays
 
 struct element {
@@ -39,9 +35,7 @@ struct element {
 };
 
 element *surf;
-int *npart; // number of generated particles in each event
-
-const double c1 = pow(1. / 2. / hbarC / TMath::Pi(), 3.0);
+int *npart;              // number of generated particles in each event
 double *cumulantDensity; // particle densities (thermal). Seems to be redundant,
                          // but needed for fast generation
 double totalDensity;     // sum of all thermal densities

--- a/src/include/const.h
+++ b/src/include/const.h
@@ -1,9 +1,12 @@
 #ifndef INCLUDE_CONST_H_
 #define INCLUDE_CONST_H_
 
+#include <cmath>
+
 // some general constants etc
 
 const double gevtofm = 5.067728853;
-const double hbarC = 1. / 5.067728853;
+const double hbarC = 1. / gevtofm;
+const double C_Feq = (pow(0.5 / M_PI / hbarC, 3));
 
 #endif // INCLUDE_CONST_H_

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -5,7 +5,7 @@
 
 namespace params {
 extern std::string surface_file, output_directory;
-extern bool bulk_viscosity_enabled, createRootOutput, shear_viscosity_enabled;
+extern bool bulk_viscosity_enabled, create_root_output, shear_viscosity_enabled;
 extern int NEVENTS;
 extern double dx, dy, deta;
 extern double ecrit, speed_of_sound_squared, ratio_pressure_energydensity;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
   gen::generate(); // one call for NEVENTS
 
   // ROOT output disabled by default
-  if (params::createRootOutput) {
+  if (params::create_root_output) {
 
     // Initialize ROOT output
     std::string root_output_file =

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -30,7 +30,7 @@ void readParams(const std::string &filename) {
     getline(fin, line);
     istringstream sline(line);
     sline >> parName >> parValue;
-    if (parName == "surface")
+    if (parName == "surface_file")
       surface_file = parValue;
     else if (parName == "output_dir")
       output_directory = parValue;
@@ -57,7 +57,7 @@ void readParams(const std::string &filename) {
 
 void printParameters() {
   cout << "======= parameters ===========\n";
-  cout << "surface = " << surface_file << endl;
+  cout << "surface_file = " << surface_file << endl;
   cout << "output_dir = " << output_directory << endl;
   cout << "number_of_events = " << NEVENTS << endl;
   cout << "shear_visc_on = " << shear_viscosity_enabled << endl;

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -9,7 +9,7 @@ using namespace std;
 namespace params {
 
 std::string surface_file{"unset"}, output_directory{"unset"};
-bool bulk_viscosity_enabled{false}, createRootOutput{false},
+bool bulk_viscosity_enabled{false}, create_root_output{false},
     shear_viscosity_enabled{false};
 int NEVENTS;
 double dx{0}, dy{0}, deta{0.05};
@@ -46,8 +46,8 @@ void readParams(const std::string &filename) {
       speed_of_sound_squared = std::stod(parValue);
     else if (parName == "ratio_pressure_energydensity")
       ratio_pressure_energydensity = std::stod(parValue);
-    else if (parName == "createRootOutput")
-      createRootOutput = std::stoi(parValue);
+    else if (parName == "create_root_output")
+      create_root_output = std::stoi(parValue);
     else if (parName[0] == '!')
       cout << "CCC " << sline.str() << endl;
     else
@@ -66,7 +66,7 @@ void printParameters() {
   cout << "cs2 = " << speed_of_sound_squared << endl;
   cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity
        << endl;
-  cout << "createRootOutput = " << createRootOutput << endl;
+  cout << "create_root_output = " << create_root_output << endl;
   cout << "======= end parameters =======\n";
 }
 

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -1,5 +1,3 @@
-#include <cstdlib>
-#include <cstring>
 #include <fstream>
 #include <iostream>
 #include <sstream>


### PR DESCRIPTION
I noticed the naming scheme of the config keys was not uniform and since there are already breaking changes I thought I clarify the `surface` config key by renaming it.                                                                                                                                                                                                            
 
 
### What I did
- Renamed config key `surface`, used to specify the freezeout surface file, to `surface_file` to clarify key.
- Renamed config key `createRootOutput`, used to enable ROOT output, to `create_root_output` to unify naming convention.
- Improved code structure slightly and removed redundant code.
 
 
### What I tested
- Compiled and ran sampler with the new keys and encountered no issues.