### PR TITLE
Improve command line parsing and fix `--version` bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 ## SMASH-hadron-sampler-3.1.1
 Date: 2025-02-17
 
-* :heavy_plus_sign: Fix that introduces the command line options `./sampler --version` to get the version of the sampler executable
+* :heavy_plus_sign: Fix that introduces the command line option `./sampler --version` to get the version of the sampler executable
 
 [Link to diff from previous version](https://github.com/smash-transport/smash-hadron-sampler/compare/SMASH-hadron-sampler-3.1...SMASH-hadron-sampler-3.1.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,12 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
-* :left_right_arrow: Renamed config key `surface`, used to specify the freezeout surface file, to `surface_file` to clarify key.
-* :left_right_arrow: Renamed config key `createRootOutput`, used to enable ROOT output, to `create_root_output` to unify naming convention.
-* :left_right_arrow: Renamed config key `spectra_dir`, used to specify the output directory, to `output_dir`.
-* :left_right_arrow: Changed the command line parameters used to run the sampler to clarify their usage.
-* :heavy_plus_sign: Added optional command line parameters to overwrite the `surface` and `output_dir` keys in the config file.
+* :left_right_arrow: Renamed config key `surface`, used to specify the freezeout surface file, to `surface_file` to clarify key
+* :left_right_arrow: Renamed config key `spectra_dir`, used to specify the output directory, to `output_dir`
+* :left_right_arrow: ROOT output is now disabled by default, it can be enabled in the config by setting `create_root_output` parameter to 1
+* :left_right_arrow: Changed the command line parameters used to run the sampler to clarify their usage (see README.md for detailed info on options and usage)
+* :heavy_plus_sign: Added optional command line parameters to overwrite the `surface` and `output_dir` keys in the config file (see README.md for detailed info on options and usage)
 * :sos: Fix problems with thread safety from ROOT objects
-* :left_right_arrow: ROOT output is now disabled by default, it can be enabled in the config by setting createRootOutput parameter to 1
 
 
 ## SMASH-hadron-sampler-3.1.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+# Minimum cmake version this is tested on
+cmake_minimum_required(VERSION 3.16 FATAL_ERROR)
+
+# The name, version and language of the project
 project(
   SMASH-hadron-sampler
   VERSION "3.1.1"
@@ -8,7 +11,10 @@ set(SAMPLER_VERSION "${SMASH-hadron-sampler_VERSION}")
 # dirty (for development on the way to next release)
 set(SAMPLER_VERSION "${SAMPLER_VERSION}-next")
 
-include(CTest)
+# Fail if cmake is called in the source directory
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+  message(FATAL_ERROR "You don't want to configure in the source directory!")
+endif()
 
 # Tell cmake where to find modules
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
@@ -98,6 +104,9 @@ if(ROOT_FOUND)
 endif()
 
 target_link_libraries(sampler ${SAMPLER_LIBRARIES})
+
+# enable standard CTest
+include(CTest)
 
 message(STATUS "BUILD_TESTING=${BUILD_TESTING}")
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ In this config file the location of the freezeout hypersurface file, the path to
 There are additional command line parameters with which the freezeout hypersurface file, the output directory, and a number prefix for parallel runs can be specified.
 All possible command line parameters are:
 
+    -h, --help                  Print overview of command line options.
     -c, --config <file>         Mandatory parameter to specify the config file.
     -n, --num <integer>         Optional number to create a random seed, useful to run several
                                 instances of the sampler in parallel. The number is also the
@@ -68,6 +69,7 @@ All possible command line parameters are:
                                 by "output_dir" in the config file.
     -s, --surface <file>        Optional parameter to overwrite the freezeout hypersurface
                                 file given by "surface_file" in the config file.
+    -q, --quiet                 Suppress the disclaimer and config parameters print-out.
     --version                   Print version of the sampler executable.
 
 Example usage:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For details about the sampling algorithm, please consult [I. Karpenko et al., Ph
 
 
 ## Prerequisites
-- [cmake](https://cmake.org) version &ge; 3.15.4
+- [cmake](https://cmake.org) version &ge; 3.16 or higher
 - [SMASH](https://github.com/smash-transport/smash) version 3.2, as well as prerequisites therein
 - [ROOT](https://root.cern.ch) version &ge; 6.06
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # SMASH Hadron Sampler
 
-This sampler is meant to be applied in hybrid models, simulating heavy-ion collisions in the high temperature or baryon-density region. More precisely it provides an interface between the macroscopic hydrodynamic evolution of the fireball and the hadronic afterburner. During the hydrodynamic evolution a hypersurface of constant energy density (the switching energy density) is created. Each element on the hypersurface needs then be transformed into a list of particles with properties loosely provided by the macroscopic properties of the hypersurface elements. This process of particlization is performed by means of the hadron sampler provided within this project. It is designed to couple the [3+1D viscous hydrodynamic code vhlle](https://github.com/yukarpenko/vhlle) to the [hadronic transport model SMASH](https://smash-transport.github.io). For details about the sampling algorithm, please consult [I. Karpenko et al., Phys. Rev. C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339).
+This sampler is meant to be applied in hybrid models, simulating heavy-ion collisions in the high temperature or baryon-density region.
+More precisely it provides an interface between the macroscopic hydrodynamic evolution of the fireball and the hadronic afterburner.
+During the hydrodynamic evolution a hypersurface of constant energy density (the switching energy density) is created.
+Each element on the hypersurface needs then be transformed into a list of particles with properties loosely provided by the macroscopic properties of the hypersurface elements.
+This process of particlization is performed by means of the hadron sampler provided within this project.
+It is designed to couple the [3+1D viscous hydrodynamic code vhlle](https://github.com/yukarpenko/vhlle) to the [hadronic transport model SMASH](https://smash-transport.github.io).
+For details about the sampling algorithm, please consult [I. Karpenko et al., Phys. Rev. C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339).
 
 > [!NOTE]
-> Please cite the following two papers when using the SMASH hadron sampler:
+> Please cite the following two papers when using the SMASH-hadron-sampler:
 > - [I. Karpenko et al., Phys. Rev. C 91 (2015) 6, 064901](https://inspirehep.net/literature/1343339)
 > - [A. Schäfer et al., arXiv:2112.08724](https://arxiv.org/abs/2112.08724)
 
@@ -18,8 +24,10 @@ This sampler is meant to be applied in hybrid models, simulating heavy-ion colli
 
 
 ## Install instructions
-It is expected that the output of this sampler is used in combination with the SMASH transport model. We therefore assume SMASH was already compiled and is available to be used as an external library. All necessary prerequisites are also assumed to already be installed.
-If not, install instructions can be found [here](https://github.com/smash-transport/smash/blob/main/README.md).
+It is expected that the output of this sampler is used in combination with the SMASH transport model.
+We therefore assume SMASH was already compiled and is available to be used as an external library.
+All necessary prerequisites are also assumed to already be installed.
+If not, install instructions can be found [here](https://github.com/smash-transport/smash/blob/main/INSTALL.md).
 
 To compile the project, first set the environment variable to the smash directory:
 
@@ -49,7 +57,7 @@ To run the sampler, execute the following command in the `build` directory:
 where `<file>` needs to be the path of the configuration file.
 In this config file the location of the freezeout hypersurface file, the path to the output directory, and all other necessary parameters can be specified.
 
-There are additional command line parameters with which the hypersurface freezeout file, the output directory, and a number prefix for parallel runs can be specified.
+There are additional command line parameters with which the freezeout hypersurface file, the output directory, and a number prefix for parallel runs can be specified.
 All possible command line parameters are:
 
     -c, --config <file>         Mandatory parameter to specify the config file.
@@ -58,7 +66,7 @@ All possible command line parameters are:
                                 ROOT output filename.
     -o, --output <directory>    Optional parameter to overwrite the output directory given
                                 by "output_dir" in the config file.
-    -s, --surface <file>        Optional parameter to overwrite the hypersurface freezeout
+    -s, --surface <file>        Optional parameter to overwrite the freezeout hypersurface
                                 file given by "surface_file" in the config file.
     --version                   Print version of the sampler executable.
 
@@ -88,6 +96,9 @@ Optional parameters:
     ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
     create_root_output            Enables ROOT output if set to 1.      Default is 0 (false).
 
+
+> [!NOTE]
+> Lines in the config file can be commented out by using an exclamation point in the beginning of a line (e.g., `! This is a comment`).
 
 > [!TIP]
 > The repository provides an example config file named `config-example`.

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -89,11 +89,11 @@ void load(const char *filename, int N) {
   Nelem = N;
   surf = new element[Nelem];
 
-  pList = new smash::ParticleData **[params::NEVENTS];
-  for (int i = 0; i < params::NEVENTS; i++) {
+  pList = new smash::ParticleData **[params::number_of_events];
+  for (int i = 0; i < params::number_of_events; i++) {
     pList[i] = new smash::ParticleData *[NPartBuf];
   }
-  npart = new int[params::NEVENTS];
+  npart = new int[params::number_of_events];
 
   cout << "reading " << N << " lines from  " << filename << "\n";
   ifstream fin(filename);
@@ -227,7 +227,7 @@ void generate() {
   const double gmumu[4] = {1., -1., -1., -1.};
   TF1 *fthermal = new TF1("fthermal", ffthermal, 0.0, 10.0, 4);
   TLorentzVector mom;
-  for (int iev = 0; iev < params::NEVENTS; iev++)
+  for (int iev = 0; iev < params::number_of_events; iev++)
     npart[iev] = 0;
   int nmaxiter = 0;
   int ntherm_fail = 0;
@@ -292,7 +292,7 @@ void generate() {
     double rval, dvEff = 0., W;
     // dvEff = dsigma_mu * u^mu
     dvEff = surf[iel].dsigma[0];
-    for (int ievent = 0; ievent < params::NEVENTS; ievent++) {
+    for (int ievent = 0; ievent < params::number_of_events; ievent++) {
       // ---- number of particles to generate
       int nToGen = 0;
       if (dvEff * totalDensity < 0.01) {

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -95,7 +95,7 @@ void load(const char *filename, int N) {
   }
   npart = new int[params::number_of_events];
 
-  cout << "reading " << N << " lines from  " << filename << "\n";
+  cout << "Read " << N << " lines from '" << filename << "'\n";
   ifstream fin(filename);
   if (!fin) {
     cout << "cannot read file " << filename << endl;

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -6,14 +6,13 @@
 namespace params {
 extern std::string surface_file, output_directory;
 extern bool bulk_viscosity_enabled, create_root_output, shear_viscosity_enabled;
-extern int NEVENTS;
+extern int number_of_events;
 extern double dx, dy, deta;
 extern double ecrit, speed_of_sound_squared, ratio_pressure_energydensity;
 // extern double Temp, mu_b, mu_q, mu_s;
 
-// ---- Routines ----
-void readParams(const std::string &filename);
-void printParameters();
+void print_config_parameters();
+void read_configuration_file(const std::string &filename);
 } // namespace params
 
 #endif // INCLUDE_PARAMS_H_

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -2,6 +2,7 @@
 #define INCLUDE_PARAMS_H_
 
 #include <string>
+#include <vector>
 
 namespace params {
 extern std::string surface_file, output_directory;
@@ -10,8 +11,12 @@ extern int number_of_events;
 extern double dx, dy, deta;
 extern double ecrit, speed_of_sound_squared, ratio_pressure_energydensity;
 // extern double Temp, mu_b, mu_q, mu_s;
+extern std::vector<std::string> comments_in_config_file,
+    unknown_parameters_in_config_file;
 
 void print_config_parameters();
+void print_comments_and_unknown_parameters_of_config_file(
+    std::vector<std::string> comments_or_unknowns_in_config_file);
 void read_configuration_file(const std::string &filename);
 } // namespace params
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,11 @@
 #include <TFile.h>
 #include <TROOT.h>
 #include <TRandom3.h>
-#include <fstream>
-#include <string>
 #include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <getopt.h>
+#include <string>
 
 #include "build_metadata.h"
 #include "gen.h"
@@ -13,7 +15,8 @@
 
 using namespace std;
 int getNlines(const char *filename);
-int readCommandLine(int argc, char **argv);
+void print_disclaimer();
+void usage(const int exit_status, const std::string &program_name);
 
 using params::number_of_events;
 using params::output_directory;
@@ -22,14 +25,100 @@ using params::surface_file;
 /**
  * Main program
  * samples hadrons from freezeout hypersurface
+ *
+ * Does command line parsing
+ *
+ * \param[in] argc Number of arguments on command-line
+ * \param[in] argv List of arguments on command-line
+ * \return Either 0 or EXIT_FAILURE.
  */
-int main(int argc, char **argv) {
+int main(int argc, char *argv[]) {
+  constexpr option long_options[] = {{"config", required_argument, 0, 'c'},
+                                     {"help", no_argument, 0, 'h'},
+                                     {"num", required_argument, 0, 'n'},
+                                     {"output", required_argument, 0, 'o'},
+                                     {"surface", required_argument, 0, 's'},
+                                     {"quiet", no_argument, 0, 'q'},
+                                     {"version", no_argument, 0, 0},
+                                     {nullptr, 0, 0, 0}};
+
+  // strip any path to program_name
+  const std::string program_name =
+      std::filesystem::path(argv[0]).filename().native();
+
+  std::string num{"0"};
+  std::string configuration, command_line_output_dir{""},
+      command_line_surface_file{""};
+  bool suppress_disclaimer_and_parameter_printout = false;
+
+  // parse command-line arguments
+  int option;
+  while ((option = getopt_long(argc, argv, "c:hn:o:s:q", long_options,
+                               nullptr)) != -1) {
+    switch (option) {
+    case 'c':
+      configuration = optarg;
+      break;
+    case 'h':
+      usage(EXIT_SUCCESS, program_name);
+      break;
+    case 'n':
+      num = optarg;
+      break;
+    case 'o':
+      command_line_output_dir = optarg;
+      break;
+    case 's':
+      command_line_surface_file = optarg;
+      break;
+    case 'q':
+      suppress_disclaimer_and_parameter_printout = true;
+      break;
+    case 0: // --version case
+      std::printf("%s\n"
+#ifdef GIT_BRANCH
+                  "Branch   : %s\n"
+#endif
+                  "System   : %s\nCompiler : %s %s\n"
+                  "Date     : %s\n",
+                  SAMPLER_VERSION,
+#ifdef GIT_BRANCH
+                  GIT_BRANCH,
+#endif
+                  CMAKE_SYSTEM, CMAKE_CXX_COMPILER_ID,
+                  CMAKE_CXX_COMPILER_VERSION, BUILD_DATE);
+      std::exit(EXIT_SUCCESS);
+    default:
+      usage(EXIT_FAILURE, program_name);
+    }
+  }
+
+  // Abort if there are unhandled arguments left.
+  if (optind < argc) {
+    std::cout << "\n"
+              << argv[0] << ": invalid argument -- '" << argv[optind] << "'\n";
+    usage(EXIT_FAILURE, program_name);
+  }
+
+  params::read_configuration_file(configuration);
+  if (!command_line_surface_file.empty()) {
+    params::surface_file = command_line_surface_file;
+  }
+  if (!command_line_output_dir.empty()) {
+    params::output_directory = command_line_output_dir;
+  }
+
+  if (!suppress_disclaimer_and_parameter_printout) {
+    print_disclaimer();
+    params::print_config_parameters();
+  }
+
   ROOT::EnableThreadSafety();
-  // command-line parameters
-  int prefix = readCommandLine(argc, argv);
-  params::print_config_parameters();
   const auto time0 = std::chrono::system_clock::now();
-  const int ranseed = std::chrono::duration_cast<std::chrono::seconds>(time0.time_since_epoch()).count() + prefix * 16;
+  const int ranseed =
+      std::chrono::duration_cast<std::chrono::seconds>(time0.time_since_epoch())
+          .count() +
+      std::stoi(num) * 16;
 
   TRandom3 *random3 = new TRandom3();
   random3->SetSeed(ranseed);
@@ -51,8 +140,7 @@ int main(int argc, char **argv) {
   // ROOT output disabled by default
   if (params::create_root_output) {
     // Initialize ROOT output
-    std::string root_output_file =
-        output_directory + "/" + std::to_string(prefix) + ".root";
+    std::string root_output_file = output_directory + "/" + num + ".root";
     TFile *outputFile = new TFile(root_output_file.c_str(), "RECREATE");
     outputFile->cd();
     MyTree *treeIni = new MyTree(static_cast<const char *>("treeini"));
@@ -69,68 +157,19 @@ int main(int argc, char **argv) {
   write_oscar_output();
 
   const auto end_time = std::chrono::steady_clock::now();
-  const auto execution_time = std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time);
-  std::cout << "Event generation done (execution time: " << execution_time.count() << " [sec])." << std::endl;
+  const auto execution_time =
+      std::chrono::duration_cast<std::chrono::seconds>(end_time - start_time);
+  std::cout << "Event generation done (execution time: "
+            << execution_time.count() << " [sec])." << std::endl;
   return 0;
-}
-
-int readCommandLine(int argc, char **argv) {
-  if (argc == 1) {
-    cout << "ERROR: Missing command line parameters!" << endl;
-    exit(1);
-  }
-  bool is_config_given = false;
-  int prefix = 0;
-  int iarg = 1;
-  while (iarg < argc - 1) {
-    if (strcmp(argv[iarg], "--config") == 0 || strcmp(argv[iarg], "-c") == 0) {
-      params::read_configuration_file(argv[iarg + 1]);
-      is_config_given = true;
-      iarg += 2;
-    } else if (strcmp(argv[iarg], "--num") == 0 ||
-               strcmp(argv[iarg], "-n") == 0) {
-      prefix = atoi(argv[iarg + 1]);
-      iarg += 2;
-    } else if (strcmp(argv[iarg], "--output") == 0 ||
-               strcmp(argv[iarg], "-o") == 0) {
-      output_directory = argv[iarg + 1];
-      iarg += 2;
-    } else if (strcmp(argv[iarg], "--surface") == 0 ||
-               strcmp(argv[iarg], "-s") == 0) {
-      surface_file = argv[iarg + 1];
-      iarg += 2;
-    } else if (strcmp(argv[1], "--version") == 0) {
-      std::printf("%s\n"
-#ifdef GIT_BRANCH
-                  "Branch   : %s\n"
-#endif
-                  "System   : %s\nCompiler : %s %s\n"
-                  "Date     : %s\n",
-                  SAMPLER_VERSION,
-#ifdef GIT_BRANCH
-                  GIT_BRANCH,
-#endif
-                  CMAKE_SYSTEM, CMAKE_CXX_COMPILER_ID,
-                  CMAKE_CXX_COMPILER_VERSION, BUILD_DATE);
-      std::exit(EXIT_SUCCESS);
-    } else {
-      cout << "Unknown command line parameter: " << argv[iarg] << endl;
-      iarg++;
-    }
-  }
-  if (!is_config_given) {
-    cout << "ERROR: No config file provided." << endl;
-    exit(126);
-  }
-  return prefix;
 }
 
 /// Function to get the number of lines in the freezeout data file
 int getNlines(const char *filename) {
   std::ifstream fin(filename);
   if (!fin) {
-    std::cout << "getNlines function error: Cannot open file " << filename
-              << std::endl;
+    std::cerr << "ERROR: getNlines function cannot open freezeout file "
+              << filename << std::endl;
     exit(1);
   }
   std::string line;
@@ -140,4 +179,64 @@ int getNlines(const char *filename) {
   };
   fin.close();
   return number_of_lines;
+}
+
+/// Print the disclaimer.
+void print_disclaimer() {
+  std::cout
+      << "###################################################################"
+      << "#############"
+      << "\n"
+      << "\n"
+      << " This is SMASH-hadron-sampler version: " << SAMPLER_VERSION << "\n"
+      << "\n"
+      << " Distributed under the GNU General Public License 3.0"
+      << " (GPLv3 or later)."
+      << "\n"
+      << " See LICENSE file for details."
+      << "\n"
+      << "\n"
+      << " Please cite the following papers when using the SMASH-hadron-sampler"
+      << "\n"
+      << "      [1] I. Karpenko et al., Phys. Rev. C 91 (2015) 6, 064901"
+      << "\n"
+      << "      [2] A. Schäfer et al., arXiv:2112.08724"
+      << "\n"
+      << "\n"
+      << " Report issues via GitHub at"
+      << "\n"
+      << " https://github.com/smash-transport/smash-hadron-sampler"
+      << "\n"
+      << "\n"
+      << "###################################################################"
+      << "#############"
+      << "\n"
+      << "\n";
+}
+
+/**
+ * Prints usage information and exits the program
+ *
+ * \param[out] exit_status Exit status to return
+ * \param[in] program_name Name of the program
+ *
+ * usage() is called when either the `--help` or `-h` command line
+ * options are given to the program; in this case, the exit status is
+ * EXIT_SUCCESS, or when an unknown option is given; in this case,
+ * the exit status is EXIT_FAIL.
+ */
+void usage(const int exit_status, const std::string &program_name) {
+  std::printf("\nUsage: %s [option]\n\n", program_name.c_str());
+  std::printf(
+      "  -h, --help              print this help message and exit\n"
+      "\n"
+      "  -c, --config <file>     path to input configuration file\n"
+      "  -n, --num <int>         specify integer to create random seed "
+      "(default: 0)\n"
+      "  -o, --output <dir>      override output directory config value\n"
+      "  -s, --surface <dir>     override hypersurface freezeout config value\n"
+      "\n"
+      "  -q, --quiet             suppress disclaimer print-out\n"
+      "  --version               print version of sampler executable\n\n");
+  std::exit(exit_status);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,6 +107,13 @@ int main(int argc, char *argv[]) {
   if (!command_line_output_dir.empty()) {
     params::output_directory = command_line_output_dir;
   }
+  if (params::surface_file == "unset" || params::output_directory == "unset") {
+    std::cerr << "ERROR: Config key 'surface_file' or 'output_dir' not set. "
+                 "Please check your configuration file and the provided "
+                 "command line arguments."
+              << std::endl;
+    std::exit(1);
+  }
 
   if (!suppress_disclaimer_and_parameter_printout) {
     print_disclaimer();
@@ -170,7 +177,7 @@ int getNlines(const char *filename) {
   if (!fin) {
     std::cerr << "ERROR: getNlines function cannot open freezeout file "
               << filename << std::endl;
-    exit(1);
+    std::exit(1);
   }
   std::string line;
   int number_of_lines = 0;

--- a/src/oscaroutput.cpp
+++ b/src/oscaroutput.cpp
@@ -13,7 +13,7 @@ void write_oscar_output() {
   std::unique_ptr<smash::OutputInterface> OscarOutput = create_oscar_output(
       "Oscar2013", "Particles", OutputPath, smash::OutputParameters());
 
-  for (int iev = 0; iev < params::NEVENTS; iev++) {
+  for (int iev = 0; iev < params::number_of_events; iev++) {
     // Create Particles oject which contains the full particle list of each
     // event
     std::unique_ptr<smash::Particles> particles =

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -11,63 +11,73 @@ namespace params {
 std::string surface_file{"unset"}, output_directory{"unset"};
 bool bulk_viscosity_enabled{false}, create_root_output{false},
     shear_viscosity_enabled{false};
-int NEVENTS;
+int number_of_events;
 double dx{0}, dy{0}, deta{0.05};
 double ecrit, speed_of_sound_squared{0.15}, ratio_pressure_energydensity{0.15};
 // double Temp, mu_b, mu_q, mu_s ;
 
-// ############ reading and processing the parameters
-
-void readParams(const std::string &filename) {
+/// Read and process configuration file parameters
+void read_configuration_file(const std::string &filename) {
   std::string parName, parValue;
-  ifstream fin(filename.c_str());
+  std::ifstream fin(filename.c_str());
   if (!fin.is_open()) {
-    cout << "ERROR: Cannot open config file " << filename << endl;
+    std::cerr << "ERROR: Cannot open config file " << filename << std::endl;
     exit(1);
   }
   while (fin.good()) {
     std::string line;
     getline(fin, line);
-    istringstream sline(line);
+    std::istringstream sline(line);
     sline >> parName >> parValue;
-    if (parName == "surface_file")
+    if (parName == "surface_file") {
       surface_file = parValue;
-    else if (parName == "output_dir")
+    } else if (parName == "output_dir") {
       output_directory = parValue;
-    else if (parName == "number_of_events")
-      NEVENTS = std::stoi(parValue);
-    else if (parName == "shear")
+    } else if (parName == "number_of_events") {
+      number_of_events = std::stoi(parValue);
+    } else if (parName == "shear") {
       shear_viscosity_enabled = std::stoi(parValue);
-    else if (parName == "bulk")
+    } else if (parName == "bulk") {
       bulk_viscosity_enabled = std::stoi(parValue);
-    else if (parName == "ecrit")
+    } else if (parName == "ecrit") {
       ecrit = std::stod(parValue);
-    else if (parName == "cs2")
+    } else if (parName == "cs2") {
       speed_of_sound_squared = std::stod(parValue);
-    else if (parName == "ratio_pressure_energydensity")
+    } else if (parName == "ratio_pressure_energydensity") {
       ratio_pressure_energydensity = std::stod(parValue);
-    else if (parName == "create_root_output")
+    } else if (parName == "create_root_output") {
       create_root_output = std::stoi(parValue);
-    else if (parName[0] == '!')
-      cout << "CCC " << sline.str() << endl;
-    else
-      cout << "UUU " << sline.str() << endl;
+    } else if (parName[0] == '!') {
+      std::cout << "Comment in config: '" << sline.str() << "'" << std::endl;
+    } else {
+      std::cout << "Unknown config parameter: '" << sline.str() << "'"
+                << std::endl;
+    }
   }
 }
 
-void printParameters() {
-  cout << "======= parameters ===========\n";
-  cout << "surface_file = " << surface_file << endl;
-  cout << "output_dir = " << output_directory << endl;
-  cout << "number_of_events = " << NEVENTS << endl;
-  cout << "shear_visc_on = " << shear_viscosity_enabled << endl;
-  cout << "bulk_visc_on = " << bulk_viscosity_enabled << endl;
-  cout << "ecrit = " << ecrit << endl;
-  cout << "cs2 = " << speed_of_sound_squared << endl;
-  cout << "ratio_pressure_energydensity = " << ratio_pressure_energydensity
-       << endl;
-  cout << "create_root_output = " << create_root_output << endl;
-  cout << "======= end parameters =======\n";
+/// Print config parameters to terminal
+void print_config_parameters() {
+  std::cout << "# ---------------------- parameters used for sampler run "
+               "-----------------------"
+            << "\n"
+            << "surface_file:                 " << surface_file << "\n"
+            << "output_dir:                   " << output_directory << "\n"
+            << "number_of_events:             " << number_of_events << "\n"
+            << "shear:                        " << shear_viscosity_enabled
+            << "\n"
+            << "bulk:                         " << bulk_viscosity_enabled
+            << "\n"
+            << "ecrit:                        " << ecrit << "\n"
+            << "cs2:                          " << speed_of_sound_squared
+            << "\n"
+            << "ratio_pressure_energydensity: " << ratio_pressure_energydensity
+            << "\n"
+            << "create_root_output:           " << create_root_output << "\n"
+            << "# -------------------------------------------------------"
+               "-----------------------"
+            << "\n"
+            << "\n";
 }
 
 } // namespace params

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -15,6 +15,8 @@ int number_of_events;
 double dx{0}, dy{0}, deta{0.05};
 double ecrit, speed_of_sound_squared{0.15}, ratio_pressure_energydensity{0.15};
 // double Temp, mu_b, mu_q, mu_s ;
+std::vector<std::string> comments_in_config_file,
+    unknown_parameters_in_config_file;
 
 /// Read and process configuration file parameters
 void read_configuration_file(const std::string &filename) {
@@ -22,7 +24,7 @@ void read_configuration_file(const std::string &filename) {
   std::ifstream fin(filename.c_str());
   if (!fin.is_open()) {
     std::cerr << "ERROR: Cannot open config file " << filename << std::endl;
-    exit(1);
+    std::exit(1);
   }
   while (fin.good()) {
     std::string line;
@@ -48,11 +50,18 @@ void read_configuration_file(const std::string &filename) {
     } else if (parName == "create_root_output") {
       create_root_output = std::stoi(parValue);
     } else if (parName[0] == '!') {
-      std::cout << "Comment in config: '" << sline.str() << "'" << std::endl;
+      comments_in_config_file.push_back(line);
     } else {
-      std::cout << "Unknown config parameter: '" << sline.str() << "'"
-                << std::endl;
+      unknown_parameters_in_config_file.push_back(line);
     }
+  }
+}
+
+/// Auxiliary function to print comments and unknown parameters in config file
+void print_comments_and_unknown_parameters_of_config_file(
+    std::vector<std::string> comments_or_unknowns_in_config_file) {
+  for (auto &element : comments_or_unknowns_in_config_file) {
+    std::cout << "'" << element << "'" << std::endl;
   }
 }
 
@@ -76,8 +85,22 @@ void print_config_parameters() {
             << "create_root_output:           " << create_root_output << "\n"
             << "# -------------------------------------------------------"
                "-----------------------"
-            << "\n"
-            << "\n";
+            << "\n\n";
+
+  if (!comments_in_config_file.empty()) {
+    std::cout << "Comments in configuration file:" << std::endl;
+    print_comments_and_unknown_parameters_of_config_file(
+        comments_in_config_file);
+    std::cout << "\n";
+  }
+  if (!unknown_parameters_in_config_file.empty()) {
+    std::cout << "Unknown parameters in config configuration file that will "
+                 "not be considered:"
+              << std::endl;
+    print_comments_and_unknown_parameters_of_config_file(
+        unknown_parameters_in_config_file);
+    std::cout << "\n";
+  }
 }
 
 } // namespace params


### PR DESCRIPTION
This PR improves the command line parsing and fixes the bug I introduced in commit 65b68d4 (when I merged `main` into `develop`) due to which `--version` is not working anymore (only on `develop`).

### New features
- command line parsing via `<getopt.h>`
- disclaimer which is print to the terminal before each run
- command line options: 
    - `--quiet`, `-q` (to suppress the disclaimer and parameters printout) and
    - `--help`, `-h` (to print a list of available command line options)
- slight improvements where I saw fit

@AxelKrypton, I only draft this first since I'm interested in your point of view and I suspect there is still room for improvement somewhere.