### PR TITLE
Add config key to set in which coordinate system the hydro evolution was run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :heavy_plus_sign: Added option to properly treat freeze-out hypersurface if the hydro stage provides the surface elements' position by space-time four-vectors in Cartesian coordinates (addtional to space-time four-vectors given in tau-eta coordinates).
+  Coordinates of the space-time four-vectors specifiable via new config key `hydro_coordinate_system` (options are `tau-eta` (default) and `cartesian`)
+
+
 ## SMASH-hadron-sampler-3.2
 Date: 2025-03-10
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Mandatory parameters:
     surface_file                  Path to the freezeout hypersurface file that gets sampled.
     output_dir                    Path to the output directory.
     number_of_events              Number of events that are sampled.
-    ecrit                         Critical energy density at which the hydro stopped in a
-                                  particular cell and the freezeout hypersurface was constructed.
+    ecrit                         Critical energy density at which the hydro stopped in a particular
+                                  cell and the freezeout hypersurface was constructed.
 
 
 Optional parameters:
@@ -98,6 +98,10 @@ Optional parameters:
     cs2                           Speed of sound squared.               Default is 0.15.
     ratio_pressure_energydensity  Pressure divided by energy density.   Default is 0.15.
     create_root_output            Enables ROOT output if set to 1.      Default is 0 (false).
+    hydro_coordinate_system       Coordinate system in which the position of the freeze-out
+                                  hypersurface elements from the hydro evolution are provided
+                                  (by space-time four-vectors). Possible coordinate systems
+                                  are 'tau-eta' (default) or 'cartesian'.
 
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Execute the following commands to build the project:
 
     mkdir build
     cd build
-    cmake .. -DPythia_CONFIG_EXECUTABLE=[...]/pythia8312/bin/pythia8-config
+    cmake -DPythia_CONFIG_EXECUTABLE=[...]/pythia8312/bin/pythia8-config ..
     make
 where `[...]/pythia8312` is the path to the pythia directory to which SMASH is also coupled.
 
@@ -56,9 +56,9 @@ To run the sampler, execute the following command in the `build` directory:
     ./sampler --config <file>
 
 where `<file>` needs to be the path of the configuration file.
-In this config file the location of the freezeout hypersurface file, the path to the output directory, and all other necessary parameters can be specified.
+In this config file the location of the freeze-out hypersurface file, the path to the output directory, and all other necessary parameters can be specified.
 
-There are additional command line parameters with which the freezeout hypersurface file, the output directory, and a number prefix for parallel runs can be specified.
+There are additional command line parameters with which the freeze-out hypersurface file, the output directory, and a number prefix for parallel runs can be specified.
 All possible command line parameters are:
 
     -h, --help                  Print overview of command line options.
@@ -68,7 +68,7 @@ All possible command line parameters are:
                                 ROOT output filename.
     -o, --output <directory>    Optional parameter to overwrite the output directory given
                                 by "output_dir" in the config file.
-    -s, --surface <file>        Optional parameter to overwrite the freezeout hypersurface
+    -s, --surface <file>        Optional parameter to overwrite the freeze-out hypersurface
                                 file given by "surface_file" in the config file.
     -q, --quiet                 Suppress the disclaimer and config parameters print-out.
     --version                   Print version of the sampler executable.
@@ -84,11 +84,11 @@ The following lists **all possible config parameters**:
 
 Mandatory parameters:
 
-    surface_file                  Path to the freezeout hypersurface file that gets sampled.
+    surface_file                  Path to the freeze-out hypersurface file that gets sampled.
     output_dir                    Path to the output directory.
     number_of_events              Number of events that are sampled.
     ecrit                         Critical energy density at which the hydro stopped in a particular
-                                  cell and the freezeout hypersurface was constructed.
+                                  cell and the freeze-out hypersurface was constructed.
 
 
 Optional parameters:
@@ -110,4 +110,4 @@ Optional parameters:
 > [!TIP]
 > The repository provides an example config file named `config-example`.
 
-In case this example config file is used, the `surface_file` parameter has to be set to the location of the freezeout file and the `output_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!
+In case this example config file is used, the `surface_file` parameter has to be set to the location of the freeze-out file and the `output_dir` parameter to the desired output path, either in the config file itself (instead of _/path/to/freezeout/file_ and _/output/path_) or via the command line parameters mentioned above!

--- a/config-example
+++ b/config-example
@@ -1,6 +1,7 @@
-surface_file     /path/to/freezeout/file
-output_dir       /output/path
-number_of_events 1000
-shear            1
-bulk             0
-ecrit            0.5
+surface_file            /path/to/freezeout/file
+output_dir              /output/path
+number_of_events        1000
+shear                   1
+bulk                    0
+ecrit                   0.5
+hydro_coordinate_system tau-eta

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -48,7 +48,7 @@ void fillBoostMatrix(double vx, double vy, double vz, double boostMatrix[4][4])
   const double v2 = vx * vx + vy * vy + vz * vz;
   const double gamma = 1.0 / sqrt(1.0 - v2);
   if (std::isinf(gamma) || std::isnan(gamma)) {
-    cout << "boost vector invalid; exiting\n";
+    std::cout << "boost vector invalid; exiting\n";
     exit(1);
   }
   boostMatrix[0][0] = gamma;
@@ -95,10 +95,10 @@ void load(const char *filename, int N) {
   }
   npart = new int[params::number_of_events];
 
-  cout << "Reading " << N << " lines from '" << filename << "'\n";
+  std::cout << "Reading " << N << " lines from '" << filename << "'\n";
   ifstream fin(filename);
   if (!fin) {
-    cout << "cannot read file " << filename << endl;
+    std::cout << "cannot read file " << filename << std::endl;
     exit(1);
   }
   dvMax = 0.;
@@ -106,7 +106,7 @@ void load(const char *filename, int N) {
   // ---- reading loop
   string line;
   istringstream instream;
-  cout << "1?: failbit=" << instream.fail() << endl;
+  std::cout << "1?: failbit=" << instream.fail() << std::endl;
   for (int n = 0; n < Nelem; n++) {
     getline(fin, line);
     instream.str(line);
@@ -130,7 +130,7 @@ void load(const char *filename, int N) {
     }
 
     if (instream.fail()) {
-      cout << "reading failed at line " << n << "; exiting\n";
+      std::cout << "reading failed at line " << n << "; exiting\n";
       exit(1);
     }
     // calculate in the old way
@@ -189,11 +189,11 @@ void load(const char *filename, int N) {
   else
     dsigmaMax *= 1.3;
 
-  cout << "..done.\n";
-  cout << "Veff = " << vEff << "  dvMax = " << dvMax << endl;
-  cout << "Veff(old) = " << vEffOld << endl;
-  cout << "failed elements = " << nfail << endl;
-  cout << "mu_cut elements = " << ncut << endl;
+  std::cout << "..done.\n";
+  std::cout << "Veff = " << vEff << "  dvMax = " << dvMax << std::endl;
+  std::cout << "Veff(old) = " << vEffOld << std::endl;
+  std::cout << "failed elements = " << nfail << std::endl;
+  std::cout << "mu_cut elements = " << ncut << std::endl;
   // ---- prepare some stuff to calculate thermal densities
 
   // Load SMASH hadron list
@@ -207,8 +207,8 @@ void load(const char *filename, int N) {
 
   // NPART = total number of hadron states
   NPART = database.size();
-  cout << "NPART=" << NPART << endl;
-  cout << "dsigmaMax=" << dsigmaMax << endl;
+  std::cout << "NPART=" << NPART << std::endl;
+  std::cout << "dsigmaMax=" << dsigmaMax << "\n\n";
   cumulantDensity = new double[NPART];
 }
 
@@ -322,7 +322,8 @@ void generate() {
                            part.strangeness() * surf[iel].mus +
                            part.charge() * surf[iel].muq;
         if (muf >= mass)
-          cout << " ^^ muf = " << muf << "  " << part.pdgcode() << endl;
+          std::cout << " ^^ muf = " << muf << "  " << part.pdgcode()
+                    << std::endl;
         fthermal->SetParameters(surf[iel].T, muf, mass, stat);
         // const double dfMax = part->GetFMax() ;
         int niter = 0; // number of iterations, for debug purposes
@@ -417,11 +418,16 @@ void generate() {
         acceptParticle(ievent, &part, position, momentum);
       } // coordinate accepted
     }   // events loop
-    if (iel % (Nelem / 50) == 0)
-      cout << round(iel / (Nelem * 0.01)) << " % done, maxiter= " << nmaxiter
-           << endl;
+    if (iel % (Nelem / 50) == 0) {
+      int progress_in_percent = round(iel / (Nelem * 0.01));
+      std::printf("[%3i%%] done\t(maxiter: %10i)\n", progress_in_percent,
+                  nmaxiter);
+      std::fflush(stdout);
+    }
   } // loop over all elements
-  cout << "therm_failed elements: " << ntherm_fail << endl;
+  std::cout << "\nThermodynamically failed elements: " << ntherm_fail
+            << "\n(caused by negative temperatures or if the sum\n"
+               "of thermal densities is below 0 or above 100)\n\n";
   delete fthermal;
 }
 
@@ -436,12 +442,12 @@ void acceptParticle(int ievent, const smash::ParticleTypePtr &ldef,
   pList[ievent][npart1] = new_particle;
   npart1++;
   if (std::isinf(momentum.x0()) || std::isnan(momentum.x0())) {
-    cout << "acceptPart nan: known, coord=" << position << endl;
-    exit(1);
+    std::cout << "acceptPart nan: known, coord=" << position << std::endl;
+    std::exit(1);
   }
   if (npart1 > NPartBuf) {
-    cout << "Error. Please increase gen::npartbuf\n";
-    exit(1);
+    std::cerr << "ERROR: Please increase gen::NPartBuf\n";
+    std::exit(1);
   }
 }
 

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -5,10 +5,10 @@
 #include <vector>
 
 namespace params {
-extern std::string surface_file, output_directory;
+extern std::string surface_file, output_directory, hydro_coordinate_system;
 extern bool bulk_viscosity_enabled, create_root_output, shear_viscosity_enabled;
 extern int number_of_events;
-extern double dx, dy, deta;
+extern double dx, dy, deta_dz;
 extern double ecrit, speed_of_sound_squared, ratio_pressure_energydensity;
 // extern double Temp, mu_b, mu_q, mu_s;
 extern std::vector<std::string> comments_in_config_file,

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -8,11 +8,15 @@ using namespace std;
 
 namespace params {
 
-std::string surface_file{"unset"}, output_directory{"unset"};
+std::string surface_file{"unset"}, output_directory{"unset"},
+    hydro_coordinate_system{"tau-eta"};
 bool bulk_viscosity_enabled{false}, create_root_output{false},
     shear_viscosity_enabled{false};
 int number_of_events;
-double dx{0}, dy{0}, deta{0.05};
+/* Smearing parameters dx, dy, and deta_dz
+ * No smearing in x and y direction implemented at the moment
+ */
+double dx{0}, dy{0}, deta_dz{0.05};
 double ecrit, speed_of_sound_squared{0.15}, ratio_pressure_energydensity{0.15};
 // double Temp, mu_b, mu_q, mu_s ;
 std::vector<std::string> comments_in_config_file,
@@ -49,6 +53,17 @@ void read_configuration_file(const std::string &filename) {
       ratio_pressure_energydensity = std::stod(parValue);
     } else if (parName == "create_root_output") {
       create_root_output = std::stoi(parValue);
+    } else if (parName == "hydro_coordinate_system") {
+      hydro_coordinate_system = parValue;
+      if (hydro_coordinate_system != "tau-eta" &&
+          hydro_coordinate_system != "cartesian") {
+        std::cerr << "ERROR: Only 'tau-eta' (default) or 'cartesian' are "
+                     "supported as coordinate\n"
+                     "       systems for the hydro evolution. Provided was '"
+                  << hydro_coordinate_system
+                  << "'.\n       Please update the config and try again.\n";
+        std::exit(1);
+      }
     } else if (parName[0] == '!') {
       comments_in_config_file.push_back(line);
     } else {
@@ -83,6 +98,8 @@ void print_config_parameters() {
             << "ratio_pressure_energydensity: " << ratio_pressure_energydensity
             << "\n"
             << "create_root_output:           " << create_root_output << "\n"
+            << "hydro_coordinate_system:      " << hydro_coordinate_system
+            << "\n"
             << "# -------------------------------------------------------"
                "-----------------------"
             << "\n\n";


### PR DESCRIPTION
Since I needed Cartesian vHLLE runs for the hybrid visualizations and the dynamical fluidization uses this as well, I implemented a new config key to treat those runs properly. Before my changes, this was not handled appropriately because the freeze-out hypersurface data regarding the 4-position of a particle was always transformed from `tau-eta` into `cartesian` coordinates.

After merging this PR, I will open the corresponding PR in the hybrid handler repo.

### What I did
- Add a new config key `hydro_coordinate_system` to declare in which coordinates the hydro freeze-out hypersurface (location) data is provided (options: `tau-eta` (default) or `cartesian`) [including smearing for Cartesian $z$ direction].
- Improve smearing as @yukarpenko suggested to the cubic root of the hypersurface elements `pow(dVeff, 1. / 3.)`. The old and new smearing resulted in the same observable values and distribution spectra (if needed I can provide plots).
- I also improved some minor things along the way.

### What I tested
- Ran sampler multiple times with different configs and encountered no issues.
- Plotted the following spectra for hydro runs in `cartesian` and `tau-eta` which all looked fine to me. I only included some plots for pi plus to keep this brief. Setting was 100 IC events averaged by vHLLE, then sampled 2000 events and propagated using smash for the Afterburner (AuAu, 7.7 GeV, central collisions).

#### Afterburner observables

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/e4bed706-8d5d-4274-a237-1f69d191d1bb" alt="rapidity spectra" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/5d7a0d54-3993-4b2e-b8e2-2e61ae5ee56f" alt="mT spectra" />
    </td>
  </tr>
</table>

#### Distributions directly from sampled particles list

The only peculiar thing to me is the curve at which points in time particles are sampled when using a Cartesian hydro run (`dN_dt` plot), but maybe this is fine. As always, I appreciate feedback! 🙂 

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/699fb035-5dc5-463b-8962-351322698941" alt="dN_dt" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/5c1e2c70-c6c2-4b4c-8052-2a53d67961cc" alt="dN_dx" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/883ba87b-ce51-4b1e-ad91-3b05ca233f9b" alt="dN_dz" />
    </td>
  </tr>
</table>