### PR TITLE
Sass/correct energy and prefactor

### DIFF
--- a/src/include/spin.h
+++ b/src/include/spin.h
@@ -47,9 +47,9 @@ inline double exponent(const double k, const double particle_energy,
 // particle
 inline double fermi_bose_distribution(const int spin, const double argument) {
   if (spin % 2 == 0) {
-    return 1.0 / (std::exp(argument) - 1.0);
+    return C_Feq / (std::exp(argument) - 1.0);
   } else {
-    return 1.0 / (std::exp(argument) + 1.0);
+    return C_Feq / (std::exp(argument) + 1.0);
   }
 }
 

--- a/src/spin.cpp
+++ b/src/spin.cpp
@@ -122,8 +122,10 @@ void calculate_and_set_spin_vector(const int index_event,
     std::array<double, 4> u = {freezeout_element.u[0], freezeout_element.u[1],
                                freezeout_element.u[2], freezeout_element.u[3]};
 
-    // p^0 is the particle energy in the LRF only. If the fluid is not at rest
-    // the particle energy in the global (lab) frame is p^mu u_mu
+    // p^0 denotes the particle energy in the global (lab) frame.
+    // For a fluid element with four-velocity u^mu, the combination p^mu u_mu
+    // gives the particle energy measured in the local rest frame of that fluid
+    // element. This is the energy relevant for the distribution function.
     const double particle_energy =
         p[0] * u[0] - p[1] * u[1] - p[2] * u[2] - p[3] * u[3];
 

--- a/src/spin.cpp
+++ b/src/spin.cpp
@@ -119,8 +119,13 @@ void calculate_and_set_spin_vector(const int index_event,
     std::array<double, 4> p = {
         particle->momentum().x0(), particle->momentum().x1(),
         particle->momentum().x2(), particle->momentum().x3()};
+    std::array<double, 4> u = {freezeout_element.u[0], freezeout_element.u[1],
+                               freezeout_element.u[2], freezeout_element.u[3]};
 
-    const double particle_energy = particle->momentum().x0();
+    // p^0 is the particle energy in the LRF only. If the fluid is not at rest
+    // the particle energy in the global (lab) frame is p^mu u_mu
+    const double particle_energy =
+        p[0] * u[0] - p[1] * u[1] - p[2] * u[2] - p[3] * u[3];
 
     const std::array<double, 4> theta_array =
         theta(particle->pole_mass(), vorticity, p);
@@ -165,8 +170,7 @@ void calculate_and_set_spin_vector(const int index_event,
       }
 
       if (denominator == 0.0) {
-        throw std::runtime_error(
-            "Denominator in spin vector calculation is zero.");
+        denominator = small_value;
       }
 
       // Calculate the spin vector


### PR DESCRIPTION
This PR corrects the wrong usage of particle energy. 

Previously, the particle energy was defined as $p^0$. In the global frame (Lab), the correct energy measured in the global frame is $p^\mu u_\mu$. Additionally the PR adds a missing phase-space volume factor to the Fermi/Bose-Einstein distribution.