### PR TITLE
Improve warnings and variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Also possible, but for this project less relevant, is `Deprecated` for soon-to-b
 
 ## Unreleased
 
+* :left_right_arrow: Changed the name of the key `sample_spin` into `compute_spin_vector` (boolean).
+* :left_right_arrow: Fixed bug in the calculation of Pauli-Lubanski vectors in spin.cpp
+
 ## SMASH-hadron-sampler-3.3
 Date: 2025-12-15
 

--- a/README.md
+++ b/README.md
@@ -105,13 +105,13 @@ Optional parameters:
                                   hypersurface elements from the hydro evolution are provided
                                   (by space-time four-vectors). Possible coordinate systems
                                   are 'tau-eta' (default) or 'cartesian'.
-    sample_spin                   Enables spin sampling at freezeout if set to 1. Spin 4-vectors
-                                  are assigned to all particles based on local vorticity following
+    compute_spin_vector           Enables calculation of Pauli-Lubanski vectors at freezeout if set to 1.
+                                  Spin 4-vectors are assigned to all particles based on local vorticity following
                                   [arXiv:2304.02276v2](https://arxiv.org/abs/2304.02276). Default is 0 (false).
     create_vorticity_vector_output Enables output of full vorticity 4-vectors of all particles
                                    to a dedicated file if set to 1.     Default is 0 (false).
     vorticity_file                Path to the vorticity input file from vHLLE. Mandatory if
-                                  `sample_spin` is enabled.
+                                  `compute_spin_vector` is enabled.
 
 
 > [!NOTE]

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -239,9 +239,9 @@ void enable_vorticity_storage() {
   } else if (!params::spin_vector_enabled &&
              params::vorticity_output_enabled) {
     throw std::runtime_error(
-        "Vorticity output is enabled but spin sampling is not. "
-        "Enable spin sampling in the config file by adding "
-        " the line 'sample_spin 1'.");
+        "Vorticity output is enabled but spin vector computation is not. "
+        "Enable spin vector computation in the config file by adding "
+        " the line 'compute_spin_vector 1'.");
   }
 }
 

--- a/src/gen.cpp
+++ b/src/gen.cpp
@@ -104,7 +104,7 @@ void load(const char *filename, int N) {
   dsigmaMax = 0.;
 
   // Read the vorticity tensor from file and set it in all surface cells
-  if (params::spin_sampling_enabled) {
+  if (params::spin_vector_enabled) {
     std::cout << "Setting vorticity tensor in all surface cells from file "
               << params::vorticity_file << std::endl;
     Vorticity::set_vorticity_in_surface_cells(surf, Nelem);
@@ -129,7 +129,7 @@ void load(const char *filename, int N) {
 
     // If spin sampling is enabled, load the energy density from the
     // extended freezeout surface
-    if (params::spin_sampling_enabled) {
+    if (params::spin_vector_enabled) {
       double tmp_e;
       instream >> tmp_e;
       surf[n].e = tmp_e;  // set energy density
@@ -233,10 +233,10 @@ void load(const char *filename, int N) {
 void enable_vorticity_storage() {
   // Allocate memory for the vorticity vector for each sampled particle
   // if spin sampling and vorticity output are enabled in the config
-  if (params::spin_sampling_enabled && params::vorticity_output_enabled) {
+  if (params::spin_vector_enabled && params::vorticity_output_enabled) {
     thetaStorage = std::make_unique<std::vector<std::vector<ThetaStruct>>>(
         params::number_of_events);
-  } else if (!params::spin_sampling_enabled &&
+  } else if (!params::spin_vector_enabled &&
              params::vorticity_output_enabled) {
     throw std::runtime_error(
         "Vorticity output is enabled but spin sampling is not. "
@@ -438,7 +438,7 @@ void generate() {
             acceptParticle(ievent, &part, position, momentum);
 
         // Calculate and set the spin vector if spin sampling is enabled
-        if (params::spin_sampling_enabled) {
+        if (params::spin_vector_enabled) {
           spin::calculate_and_set_spin_vector(ievent, surf[iel], particle_ptr);
         }
       }  // coordinate accepted

--- a/src/include/params.h
+++ b/src/include/params.h
@@ -7,7 +7,7 @@
 namespace params {
 extern std::string surface_file, vorticity_file, output_directory, hydro_coordinate_system;
 extern bool bulk_viscosity_enabled, create_root_output, shear_viscosity_enabled,
-    spin_sampling_enabled, vorticity_output_enabled;
+    spin_vector_enabled, vorticity_output_enabled;
 extern int number_of_events;
 extern double dx, dy, deta_dz;
 extern double ecrit, speed_of_sound_squared, ratio_pressure_energydensity;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,7 +130,7 @@ int main(int argc, char *argv[]) {
       std::stoi(num) * 16;
 
   // check input formats
-  if (params::spin_sampling_enabled) {
+  if (params::spin_vector_enabled) {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
     Vorticity::ensure_extended_freezeout_is_given();
     Vorticity::set_number_of_corona_cells();

--- a/src/oscaroutput.cpp
+++ b/src/oscaroutput.cpp
@@ -17,7 +17,7 @@ void write_oscar_output() {
   std::unique_ptr<smash::OutputInterface> OscarOutput;
 
   // Initialize Oscar output
-  if (params::spin_sampling_enabled) {
+  if (params::spin_vector_enabled) {
     smash::OutputParameters output_params;
     std::vector<std::string> particle_quantities = {
         "t",  "x",   "y",  "z",      "mass",  "p0",    "px",    "py",

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -92,7 +92,7 @@ void read_configuration_file(const std::string &filename) {
     }
   }
   // If no vorticity file was specified, set the default based on surface_file
-  if (vorticity_file == "unset") {
+  if (spin_sampling_enabled && vorticity_file == "unset") {
     std::cerr
         << "[Warning] No vorticity_file specified in config. "
            "Defaulting to 'beta.dat' in the same directory as surface_file ("

--- a/src/params.cpp
+++ b/src/params.cpp
@@ -12,7 +12,7 @@ std::string surface_file{"unset"}, vorticity_file{"unset"},
     output_directory{"unset"}, hydro_coordinate_system{"tau-eta"};
 
 bool bulk_viscosity_enabled{false}, create_root_output{false},
-    shear_viscosity_enabled{false}, spin_sampling_enabled{false},
+    shear_viscosity_enabled{false}, spin_vector_enabled{false},
     vorticity_output_enabled{false};
 int number_of_events;
 /* Smearing parameters dx, dy, and deta_dz
@@ -81,8 +81,8 @@ void read_configuration_file(const std::string &filename) {
                   << "'.\n       Please update the config and try again.\n";
         std::exit(1);
       }
-    } else if (parName == "sample_spin") {
-      spin_sampling_enabled = std::stoi(parValue);
+    } else if (parName == "compute_spin_vector") {
+      spin_vector_enabled = std::stoi(parValue);
     } else if (parName == "create_vorticity_vector_output") {
       vorticity_output_enabled = std::stoi(parValue);
     } else if (parName[0] == '!') {
@@ -92,7 +92,7 @@ void read_configuration_file(const std::string &filename) {
     }
   }
   // If no vorticity file was specified, set the default based on surface_file
-  if (spin_sampling_enabled && vorticity_file == "unset") {
+  if (spin_vector_enabled && vorticity_file == "unset") {
     std::cerr
         << "[Warning] No vorticity_file specified in config. "
            "Defaulting to 'beta.dat' in the same directory as surface_file ("
@@ -123,7 +123,7 @@ void print_config_parameters() {
             << "\n"
             << "bulk:                         " << bulk_viscosity_enabled
             << "\n"
-            << "spin:                         " << spin_sampling_enabled << "\n"
+            << "spin:                         " << spin_vector_enabled << "\n"
             << "vorticity_vector:             " << vorticity_output_enabled
             << "\n"
             << "ecrit:                        " << ecrit << "\n"

--- a/tests/spin.cpp
+++ b/tests/spin.cpp
@@ -3,6 +3,8 @@
 #include <array>
 #include <cmath>
 #include <iomanip>
+#include <iostream>
+#include <memory>
 #include <mutex>
 #include <random>
 
@@ -12,6 +14,8 @@
 #include "vorticity.h"
 
 using namespace spin;
+
+namespace {
 
 // Ensures the global ParticleType list is initialized only once using
 // std::call_once. Avoids the "Type list was already built!" exception when
@@ -61,6 +65,8 @@ int levi_civita(int i, int j, int k, int l) {
 bool expect_near(double val1, double val2, double abs_error) {
   return std::abs(val1 - val2) <= abs_error;
 }
+
+}  // namespace
 
 TEST(four_vector_square) {
   // Create a random number generator
@@ -166,14 +172,15 @@ TEST(theta_invalid_mass) {
                                             4.0,  5.0,  -2.0, -4.0, 0.0,  6.0,
                                             -3.0, -5.0, -6.0, 0.0};
   const std::array<double, 4> p = {1.0, 2.0, 3.0, 4.0};
+
   // Expect an invalid argument exception
+  bool threw = false;
   try {
     theta(mass, vorticity, p);
-    std::cout << "theta unexpectedly passed with massless particle"
-              << std::endl;
-  } catch (std::invalid_argument &e) {
-    // Exception was caught as expected
+  } catch (std::invalid_argument &) {
+    threw = true;  // Exception was caught as expected
   }
+  VERIFY(threw);
 }
 
 TEST(exponent_valid_value) {
@@ -221,15 +228,17 @@ TEST(exponent_invalid_k) {
   const double temperature = 1.0;
   const double mu = 1.0;
   const double theta_squared = -1.0;
+
   // Expect an invalid argument exception
+  bool threw = false;
   for (const double k : invalid_k_array) {
     try {
       exponent(k, energy, temperature, mu, theta_squared);
-      std::cout << "exponent unexpectedly passed with k not being a multiple "
-                << "of 1/2" << std::endl;
-    } catch (std::invalid_argument &e) {
-      // Exception was caught as expected
+    } catch (std::invalid_argument &) {
+      threw = true;  // Exception was caught as expected
     }
+    VERIFY(threw);
+    threw = false;
   }
 }
 
@@ -240,15 +249,17 @@ TEST(exponent_positive_theta_squared) {
   const double temperature = 1.0;
   const double mu = 1.0;
   const double invalid_theta_squared_array[3] = {0.0001, 1.3, 4.6};
+
   // Expect an invalid argument exception
+  bool threw = false;
   for (const double theta_squared : invalid_theta_squared_array) {
     try {
       exponent(k, energy, temperature, mu, theta_squared);
-      std::cout << "exponent unexpectedly passed with positive theta squared"
-                << std::endl;
-    } catch (std::invalid_argument &e) {
-      // Exception was caught as expected
+    } catch (std::invalid_argument &) {
+      threw = true;  // Exception was caught as expected
     }
+    VERIFY(threw);
+    threw = false;
   }
 }
 
@@ -359,13 +370,18 @@ TEST(spin_vector_valid_values) {
 
   double mu_proton = chemical_potential(&proton, surf_element);
 
+  // proton energy in global frame
+  double proton_energy =
+      proton_mom[0] * surf_element.u[0] - proton_mom[1] * surf_element.u[1] -
+      proton_mom[2] * surf_element.u[2] - proton_mom[3] * surf_element.u[3];
+
   double denominator_1 =
       1 /
-      (std::exp(exponent(-0.5, proton_mom[0], 4.3, mu_proton, theta_squared)) +
+      (std::exp(exponent(-0.5, proton_energy, 4.3, mu_proton, theta_squared)) +
        1);
   double denominator_2 =
       1 /
-      (std::exp(exponent(0.5, proton_mom[0], 4.3, mu_proton, theta_squared)) +
+      (std::exp(exponent(0.5, proton_energy, 4.3, mu_proton, theta_squared)) +
        1);
 
   double numerator_1 = -0.5 * denominator_1;
@@ -400,13 +416,18 @@ TEST(spin_vector_valid_values) {
 
   double mu_rho = chemical_potential(&rho, surf_element);
 
+  // rho energy in global frame
+  double rho_energy =
+      rho_mom[0] * surf_element.u[0] - rho_mom[1] * surf_element.u[1] -
+      rho_mom[2] * surf_element.u[2] - rho_mom[3] * surf_element.u[3];
+
   denominator_1 =
       1 /
-      (std::exp(exponent(-1.0, rho_mom[0], 4.3, mu_rho, theta_squared)) - 1);
+      (std::exp(exponent(-1.0, rho_energy, 4.3, mu_rho, theta_squared)) - 1);
   denominator_2 =
-      1 / (std::exp(exponent(0.0, rho_mom[0], 4.3, mu_rho, theta_squared)) - 1);
+      1 / (std::exp(exponent(0.0, rho_energy, 4.3, mu_rho, theta_squared)) - 1);
   double denominator_3 =
-      1 / (std::exp(exponent(1.0, rho_mom[0], 4.3, mu_rho, theta_squared)) - 1);
+      1 / (std::exp(exponent(1.0, rho_energy, 4.3, mu_rho, theta_squared)) - 1);
 
   numerator_1 = -1.0 * denominator_1;
   numerator_2 = 0.0 * denominator_2;
@@ -444,16 +465,22 @@ TEST(spin_vector_valid_values) {
 
   double mu_delta_plus = chemical_potential(&delta_plus, surf_element);
 
-  denominator_1 = 1 / (std::exp(exponent(-1.5, delta_plus_mom[0], 4.3,
+  // delta energy in global frame
+  double delta_plus_energy = delta_plus_mom[0] * surf_element.u[0] -
+                             delta_plus_mom[1] * surf_element.u[1] -
+                             delta_plus_mom[2] * surf_element.u[2] -
+                             delta_plus_mom[3] * surf_element.u[3];
+
+  denominator_1 = 1 / (std::exp(exponent(-1.5, delta_plus_energy, 4.3,
                                          mu_delta_plus, theta_squared)) +
                        1);
-  denominator_2 = 1 / (std::exp(exponent(-0.5, delta_plus_mom[0], 4.3,
+  denominator_2 = 1 / (std::exp(exponent(-0.5, delta_plus_energy, 4.3,
                                          mu_delta_plus, theta_squared)) +
                        1);
-  denominator_3 = 1 / (std::exp(exponent(0.5, delta_plus_mom[0], 4.3,
+  denominator_3 = 1 / (std::exp(exponent(0.5, delta_plus_energy, 4.3,
                                          mu_delta_plus, theta_squared)) +
                        1);
-  double denominator_4 = 1 / (std::exp(exponent(1.5, delta_plus_mom[0], 4.3,
+  double denominator_4 = 1 / (std::exp(exponent(1.5, delta_plus_energy, 4.3,
                                                 mu_delta_plus, theta_squared)) +
                               1);
 

--- a/tests/vorticity.cpp
+++ b/tests/vorticity.cpp
@@ -206,7 +206,7 @@ TEST(vorticity_file_too_few_comment_lines) {
   // directory as the surface file as default. This is ensured here)
   write_to_file(configFilePath,
                 "surface_file " + freezeoutFilePath.string() + "\n");
-  write_to_file(configFilePath, "sample_spin 1 \n");
+  write_to_file(configFilePath, "compute_spin_vector 1 \n");
   VERIFY(fs::exists(configFilePath));
 
   // Write beta.dat file with one comment line and expect error

--- a/tests/vorticity.cpp
+++ b/tests/vorticity.cpp
@@ -66,7 +66,7 @@ void reset_params() {
   params::bulk_viscosity_enabled = false;
   params::create_root_output = false;
   params::shear_viscosity_enabled = false;
-  params::spin_sampling_enabled = false;
+  params::spin_vector_enabled = false;
   params::vorticity_output_enabled = false;
 
   params::number_of_events = 0;

--- a/tests/vorticity.cpp
+++ b/tests/vorticity.cpp
@@ -1,5 +1,7 @@
 #include "vorticity.h"
 
+#include <array>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -9,9 +11,9 @@
 #include "params.h"
 #include "virtest/vir/test.h"
 
-namespace test_utils {
-
 namespace fs = std::filesystem;
+
+namespace {
 
 // Create a temporary directory and return its path
 fs::path create_temp_directory(const std::string& dir_name = "test_temp") {
@@ -79,12 +81,12 @@ void reset_params() {
   params::unknown_parameters_in_config_file.clear();
 }
 
-}  // namespace test_utils
-
 // Custom function to compare two doubles within a given tolerance
 bool expect_near(double val1, double val2, double abs_error) {
   return std::abs(val1 - val2) <= abs_error;
 }
+
+}  // namespace
 
 TEST(vorticity_default_constructor) {
   Vorticity vorticity;
@@ -157,46 +159,42 @@ TEST(boost_vorticity_to_fluid_rest_frame_matrix_multiplication) {
 }
 
 TEST(vorticity_file_does_not_exist) {
-  namespace fs = std::filesystem;
-
   // Create temporary directory
-  fs::path tempDir = test_utils::create_temp_directory();
+  fs::path tempDir = create_temp_directory();
 
   // Create paths for the config file and the vorticity file
   fs::path configFilePath = tempDir / "config_temp";
   fs::path vorticityFilePath = tempDir / "beta.dat";
 
   // Write config file
-  test_utils::write_to_file(
-      configFilePath, "vorticity_file " + vorticityFilePath.string() + "\n");
+  write_to_file(configFilePath,
+                "vorticity_file " + vorticityFilePath.string() + "\n");
+  VERIFY(fs::exists(configFilePath));
 
   // Pass config to params
-  test_utils::set_params(configFilePath);
+  set_params(configFilePath);
 
+  bool threw = false;
   try {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
-    throw std::runtime_error(
-        "ensure_vorticity_file_exists_and_check_format unexpectedly succeeded "
-        "with non-existing beta.dat file");
   } catch (const std::runtime_error& e) {
-    // Error was caught as expected
+    threw = true;  // Error was caught as expected
   }
+  VERIFY(threw);
 
   // Cleanup
   try {
-    test_utils::cleanup_temp_directory(tempDir);
+    cleanup_temp_directory(tempDir);
   } catch (const std::exception& e) {
     throw std::runtime_error(std::string("Cleanup failed: ") + e.what());
   }
   // Reset params to default values
-  test_utils::reset_params();
+  reset_params();
 }
 
 TEST(vorticity_file_too_few_comment_lines) {
-  namespace fs = std::filesystem;
-
   // Create temporary directory
-  fs::path tempDir = test_utils::create_temp_directory();
+  fs::path tempDir = create_temp_directory();
 
   // Create paths for the config file and the vorticity file
   fs::path configFilePath = tempDir / "config_temp";
@@ -206,14 +204,16 @@ TEST(vorticity_file_too_few_comment_lines) {
   // Write config file (Here we use the keyword "surface_file" instead of
   // "vorticity_file", as the sampler looks for the beta.dat file in the same
   // directory as the surface file as default. This is ensured here)
-  test_utils::write_to_file(
-      configFilePath, "surface_file " + freezeoutFilePath.string() + "\n");
+  write_to_file(configFilePath,
+                "surface_file " + freezeoutFilePath.string() + "\n");
+  write_to_file(configFilePath, "sample_spin 1 \n");
+  VERIFY(fs::exists(configFilePath));
 
   // Write beta.dat file with one comment line and expect error
-  test_utils::write_to_file(vorticityFilePath, "# Header Line 1");
+  write_to_file(vorticityFilePath, "# Header Line 1");
 
   // Pass config to params
-  test_utils::set_params(configFilePath);
+  set_params(configFilePath);
 
   // Ensure the beta.dat file exists and was set from default
   VERIFY(fs::exists(params::vorticity_file));
@@ -228,7 +228,7 @@ TEST(vorticity_file_too_few_comment_lines) {
   }
 
   // Add a second comment line to the beta.dat file and expect error
-  test_utils::write_to_file(vorticityFilePath, "# Number of corona cells: 1");
+  write_to_file(vorticityFilePath, "# Number of corona cells: 1");
 
   try {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
@@ -240,7 +240,7 @@ TEST(vorticity_file_too_few_comment_lines) {
   }
 
   // Add a third comment line not matching the expected line and expect error
-  test_utils::write_to_file(vorticityFilePath, "# Header Line 3");
+  write_to_file(vorticityFilePath, "# Header Line 3");
 
   try {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
@@ -253,34 +253,35 @@ TEST(vorticity_file_too_few_comment_lines) {
 
   // Cleanup
   try {
-    test_utils::cleanup_temp_directory(tempDir);
+    cleanup_temp_directory(tempDir);
   } catch (const std::exception& e) {
     throw std::runtime_error(std::string("Cleanup failed: ") + e.what());
   }
   // Reset params to default values
-  test_utils::reset_params();
+  reset_params();
 }
 
 TEST(vorticity_file_invalid_second_header_line) {
-  namespace fs = std::filesystem;
-
   // Create temporary directory
-  fs::path tempDir = test_utils::create_temp_directory();
+  fs::path tempDir = create_temp_directory();
 
   // Create paths for the config file and the vorticity file
   fs::path configFilePath = tempDir / "config_temp";
   fs::path vorticityFilePath = tempDir / "beta.dat";
 
   // Write config file
-  test_utils::write_to_file(
-      configFilePath, "vorticity_file " + vorticityFilePath.string() + "\n");
+  write_to_file(configFilePath,
+                "vorticity_file " + vorticityFilePath.string() + "\n");
+  VERIFY(fs::exists(configFilePath));
 
   // Write beta.dat file with invalid second comment line and expect error
-  test_utils::write_to_file(vorticityFilePath, "# Header Line 1");
-  test_utils::write_to_file(vorticityFilePath, "# Header Line");
+  write_to_file(vorticityFilePath, "# Header Line 1");
+  write_to_file(vorticityFilePath, "# Header Line");
 
   // Pass config to params
-  test_utils::set_params(configFilePath);
+  set_params(configFilePath);
+  VERIFY(fs::exists(vorticityFilePath));
+  VERIFY(fs::exists(params::vorticity_file));
 
   try {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
@@ -293,8 +294,8 @@ TEST(vorticity_file_invalid_second_header_line) {
 
   // Delete beta file and write a valid second comment line
   fs::remove(vorticityFilePath);
-  test_utils::write_to_file(vorticityFilePath, "# Header Line 1");
-  test_utils::write_to_file(vorticityFilePath, "# Number of corona cells: 1.3");
+  write_to_file(vorticityFilePath, "# Header Line 1");
+  write_to_file(vorticityFilePath, "# Number of corona cells: 1.3");
 
   try {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
@@ -307,40 +308,41 @@ TEST(vorticity_file_invalid_second_header_line) {
 
   // Cleanup
   try {
-    test_utils::cleanup_temp_directory(tempDir);
+    cleanup_temp_directory(tempDir);
   } catch (const std::exception& e) {
     throw std::runtime_error(std::string("Cleanup failed: ") + e.what());
   }
   // Reset params to default values
-  test_utils::reset_params();
+  reset_params();
 }
 
 TEST(vorticity_file_too_many_comment_lines) {
-  namespace fs = std::filesystem;
-
   // Create temporary directory
-  fs::path tempDir = test_utils::create_temp_directory();
+  fs::path tempDir = create_temp_directory();
 
   // Create paths for the config file and the vorticity file
   fs::path configFilePath = tempDir / "config_temp";
   fs::path vorticityFilePath = tempDir / "beta.dat";
 
   // Write config file
-  test_utils::write_to_file(
-      configFilePath, "vorticity_file " + vorticityFilePath.string() + "\n");
+  write_to_file(configFilePath,
+                "vorticity_file " + vorticityFilePath.string() + "\n");
+  VERIFY(fs::exists(configFilePath));
 
   // Write beta.dat file with four comment lines and expect error
-  test_utils::write_to_file(vorticityFilePath, "# Header Line 1");
-  test_utils::write_to_file(vorticityFilePath, "# Number of corona cells: 2");
-  test_utils::write_to_file(
+  write_to_file(vorticityFilePath, "# Header Line 1");
+  write_to_file(vorticityFilePath, "# Number of corona cells: 2");
+  write_to_file(
       vorticityFilePath,
       "#  τ  x  y  η  dΣ[0]  dΣ[1]  dΣ[2]  dΣ[3]  u[0]  u[1]  u[2]  u[3]  "
       "T  μB  μQ  μS  ∂₀β₀  ∂₀β₁  ∂₀β₂  ∂₀β₃  ∂₁β₀  ∂₁β₁  ∂₁β₂  ∂₁β₃  "
       "∂₂β₀  ∂₂β₁  ∂₂β₂  ∂₂β₃  ∂₃β₀  ∂₃β₁  ∂₃β₂  ∂₃β₃  ϵ");
-  test_utils::write_to_file(vorticityFilePath, "# Header Line 4");
+  write_to_file(vorticityFilePath, "# Header Line 4");
 
   // Pass config to params
-  test_utils::set_params(configFilePath);
+  set_params(configFilePath);
+  VERIFY(fs::exists(vorticityFilePath));
+  VERIFY(fs::exists(params::vorticity_file));
 
   try {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
@@ -353,49 +355,50 @@ TEST(vorticity_file_too_many_comment_lines) {
 
   // Cleanup
   try {
-    test_utils::cleanup_temp_directory(tempDir);
+    cleanup_temp_directory(tempDir);
   } catch (const std::exception& e) {
     throw std::runtime_error(std::string("Cleanup failed: ") + e.what());
   }
   // Reset params to default values
-  test_utils::reset_params();
+  reset_params();
 }
 
 TEST(vorticity_file_valid) {
-  namespace fs = std::filesystem;
-
   // Create temporary directory
-  fs::path tempDir = test_utils::create_temp_directory();
+  fs::path tempDir = create_temp_directory();
 
   // Create paths for the config file and the vorticity file
   fs::path configFilePath = tempDir / "config_temp";
   fs::path vorticityFilePath = tempDir / "beta.dat";
 
   // Write config file
-  test_utils::write_to_file(
-      configFilePath, "vorticity_file " + vorticityFilePath.string() + "\n");
+  write_to_file(configFilePath,
+                "vorticity_file " + vorticityFilePath.string() + "\n");
+  VERIFY(fs::exists(configFilePath));
 
   // Write beta.dat file with the expected comment lines
-  test_utils::write_to_file(vorticityFilePath, "# Header Line 1");
-  test_utils::write_to_file(vorticityFilePath, "# Number of corona cells: 2");
-  test_utils::write_to_file(
+  write_to_file(vorticityFilePath, "# Header Line 1");
+  write_to_file(vorticityFilePath, "# Number of corona cells: 2");
+  write_to_file(
       vorticityFilePath,
       "#  τ  x  y  η  dΣ[0]  dΣ[1]  dΣ[2]  dΣ[3]  u[0]  u[1]  u[2]  u[3]  "
       "T  μB  μQ  μS  ∂₀β₀  ∂₀β₁  ∂₀β₂  ∂₀β₃  ∂₁β₀  ∂₁β₁  ∂₁β₂  ∂₁β₃  "
       "∂₂β₀  ∂₂β₁  ∂₂β₂  ∂₂β₃  ∂₃β₀  ∂₃β₁  ∂₃β₂  ∂₃β₃  ϵ");
-  test_utils::write_to_file(vorticityFilePath,
-                            "0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 "
-                            "8.0 9.0 10.0 11.0 12.0 13.0 14.0 "
-                            "15.0 16.0 17.0 18.0 19.0 20.0 21.0 "
-                            "22.0 23.0 24.0 25.0 26.0 27.0 28.0 "
-                            "29.0 30.0 31.0 32.0 \n");
+  write_to_file(vorticityFilePath,
+                "0.0 1.0 2.0 3.0 4.0 5.0 6.0 7.0 "
+                "8.0 9.0 10.0 11.0 12.0 13.0 14.0 "
+                "15.0 16.0 17.0 18.0 19.0 20.0 21.0 "
+                "22.0 23.0 24.0 25.0 26.0 27.0 28.0 "
+                "29.0 30.0 31.0 32.0 \n");
 
   // Pass config to params
-  test_utils::set_params(configFilePath);
+  set_params(configFilePath);
+  VERIFY(fs::exists(vorticityFilePath));
+  VERIFY(fs::exists(params::vorticity_file));
 
   try {
     Vorticity::ensure_vorticity_file_exists_and_check_format();
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     throw std::runtime_error(
         "ensure_vorticity_file_exists_and_check_format unexpectedly failed "
         "with valid beta.dat file");
@@ -403,10 +406,10 @@ TEST(vorticity_file_valid) {
 
   // Cleanup
   try {
-    test_utils::cleanup_temp_directory(tempDir);
+    cleanup_temp_directory(tempDir);
   } catch (const std::exception& e) {
     throw std::runtime_error(std::string("Cleanup failed: ") + e.what());
   }
   // Reset params to default values
-  test_utils::reset_params();
+  reset_params();
 }


### PR DESCRIPTION
This PR is a general cleanup of the code base with improved variable names. The PR does the following:

1. The fix in #61 changed the expected return vales of the function `calculate_and_set_spin_vector` in `spin.cpp`. This needs to be reflected in the corresponding tests as well. This PR adjusts the tests accordingly.
2. The PR changes the name of the config key `sample_spin` into `compute_spin_vector` and renames all connected variables used as flags in the code. See Issue #60 
3. The PR reduces warnings during compilation connected to Issue #59 